### PR TITLE
fix: bug in remove when query point value has same value as a split plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kiddo Changelog
 
-## 2.0.0-beta.6
+## 2.0.0-beta.7
 
 Version 2 is a complete rewrite and rearchitecting of Kiddo. The same methods have been provided (except periodic boundary conditions, for now), but large performance improvements have been made across the board, and some improvements have been made to the ergonomics of the library also.
 Needless to say, this is a breaking change, but I hope you find the upgrade not too difficult as the improvements are significant.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 edition = "2021"
 authors = ["Scott Donnelly <scott@donnel.ly>"]
 description = "A high-performance, flexible, ergonomic k-d tree library. Ideal for geo- and astro- nearest-neighbour and k-nearest-neighbor queries"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 * [License](#license)
 
 Kiddo is ideal for super-fast spatial / geospatial lookups and nearest-neighbour / KNN queries for low-ish numbers of dimensions, where you want to ask questions such as:
- - Find the [nearest_n](https://docs.rs/kiddo/2.0.0-beta.6/kiddo/float/kdtree/struct.KdTree.html#method.nearest_n) item(s) to a query point, ordered by distance;
- - Find all items [within](https://docs.rs/kiddo/2.0.0-beta.6/kiddo/float/kdtree/struct.KdTree.html#method.within) a specified radius of a query point;
- - Find the ["best" n item(s) within](https://docs.rs/kiddo/2.0.0-beta.6/kiddo/float/kdtree/struct.KdTree.html#method.best_n_within) a specified distance of a query point, for some definition of "best"
+ - Find the [nearest_n](https://docs.rs/kiddo/2.0.0-beta.7/kiddo/float/kdtree/struct.KdTree.html#method.nearest_n) item(s) to a query point, ordered by distance;
+ - Find all items [within](https://docs.rs/kiddo/2.0.0-beta.7/kiddo/float/kdtree/struct.KdTree.html#method.within) a specified radius of a query point;
+ - Find the ["best" n item(s) within](https://docs.rs/kiddo/2.0.0-beta.7/kiddo/float/kdtree/struct.KdTree.html#method.best_n_within) a specified distance of a query point, for some definition of "best"
 
 ## Differences vs Kiddo v1.x
 
@@ -27,7 +27,7 @@ Version 2.x is a complete rewrite, providing:
 Add `kiddo` to `Cargo.toml`
 ```toml
 [dependencies]
-kiddo = "2.0.0-beta.6"
+kiddo = "2.0.0-beta.7"
 ```
 
 Add points to kdtree and query nearest n points with distance function

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -30,7 +30,7 @@ The output below was run on a Ryzen 5900X with 32Gb DDR4-3600.
 
 ```
 > cargo run --release --example serde --features="serialize"
-   Compiling kiddo v2.0.0-beta.6 (~/kiddo)
+   Compiling kiddo v2.0.0-beta.7 (~/kiddo)
     Finished release [optimized + debuginfo] target(s) in 5.18s
      Running `target/release/examples/serde`
 Cities successfully parsed from CSV: 11061987
@@ -55,7 +55,7 @@ Rkyv for serialization / deserialization
 
 ```
 > cargo run --release --example rkyv --features="serialize_rkyv"
-   Compiling kiddo v2.0.0-beta.6 (~/kiddo)
+   Compiling kiddo v2.0.0-beta.7 (~/kiddo)
     Finished release [optimized + debuginfo] target(s) in 3.91s
      Running `target/release/examples/rkyv`
 Cities successfully parsed from CSV: 11061987

--- a/src/fixed/construction.rs
+++ b/src/fixed/construction.rs
@@ -45,7 +45,7 @@ where
 
                 stem_node.extend(query);
 
-                stem_idx = if *query.get_unchecked(split_dim) < stem_node.split_val {
+                stem_idx = if *query.get_unchecked(split_dim) <= stem_node.split_val {
                     is_left_child = true;
                     stem_node.left
                 } else {
@@ -122,7 +122,7 @@ where
                 return removed;
             };
 
-            stem_idx = if query[split_dim] < stem_node.split_val {
+            stem_idx = if query[split_dim] <= stem_node.split_val {
                 stem_node.left
             } else {
                 stem_node.right

--- a/src/float/construction.rs
+++ b/src/float/construction.rs
@@ -40,7 +40,7 @@ where
 
                 stem_node.extend(query);
 
-                stem_idx = if *query.get_unchecked(split_dim) < stem_node.split_val {
+                stem_idx = if *query.get_unchecked(split_dim) <= stem_node.split_val {
                     is_left_child = true;
                     stem_node.left
                 } else {
@@ -113,7 +113,7 @@ where
                 return removed;
             };
 
-            stem_idx = if query[split_dim] < stem_node.split_val {
+            stem_idx = if query[split_dim] <= stem_node.split_val {
                 stem_node.left
             } else {
                 stem_node.right
@@ -449,5 +449,54 @@ mod tests {
         points_to_add
             .iter()
             .for_each(|point| kdtree.add(&point.0, point.1));
+    }
+
+    #[test]
+    fn test_can_handle_remove_edge_case_from_issue_12() {
+        // See: https://github.com/sdd/kiddo/issues/12
+        let pts = vec![
+            [19.2023, 7.1812],
+            [7.6427, 22.5779],
+            [26.6314, 34.8920],
+            [36.7890, 27.2663],
+            [28.3226, 8.5047],
+            [5.3914, 28.1360],
+            [5.0978, 3.6814],
+            [0.5114, 11.6552],
+            [4.7981, 21.6210],
+            [29.0030, 9.6799],
+            [35.5580, 1.8891],
+            [3.9160, 25.5702],
+            [22.2497, 31.6140],
+            [30.7110, 36.7514],
+            [0.2828, 12.4298],
+            [20.0206, 3.0635],
+            [30.6153, 2.8582],
+            [23.7179, 6.2048],
+            [13.0438, 4.2319],
+            [4.6433, 30.9660],
+            [5.0588, 5.2028],
+            [19.2023, 23.7406],
+            [37.3171, 32.7523],
+            [12.6957, 15.7080],
+            [15.6001, 14.3995],
+            [36.0203, 21.0366],
+            [6.3956, 2.7644],
+            [3.1719, 8.7039],
+            [0.9159, 12.2299],
+            [23.8157, 14.0699],
+            [27.7757, 7.3597],
+            [28.4198, 31.3427],
+            [2.3290, 6.2364],
+            [10.1126, 7.7009],
+        ];
+
+        let mut tree = KdTree::<f64, usize, 2, 32, u32>::new();
+
+        for (i, pt) in pts.iter().enumerate() {
+            tree.add(pt, i);
+        }
+
+        assert_eq!(tree.remove(&pts[0], 0), 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/2.0.0-beta.6")]
+#![doc(html_root_url = "https://docs.rs/kiddo/2.0.0-beta.7")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 
 //! # Kiddo
@@ -32,7 +32,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "2.0.0-beta.6"
+//! kiddo = "2.0.0-beta.7"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION
Fixes https://github.com/sdd/kiddo/issues/12