### PR TITLE
Fix the incorrect documentation of `fixed::distance::manhattan`

### DIFF
--- a/src/fixed/distance.rs
+++ b/src/fixed/distance.rs
@@ -7,10 +7,9 @@
 
 use crate::fixed::kdtree::Axis;
 
-/// Returns the squared euclidean distance between two points. When you only
-/// need to compare distances, rather than having the exact distance between
-/// the points, this metric is beneficial because it avoids the expensive square
-/// root computation.
+/// Returns the Manhattan / "taxi cab" distance between two points.
+///
+/// Faster than squared Euclidean, and just as effective if not more so in higher-dimensional spaces
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Copied the description from the equivalent distance metric function `float::distance::manhattan`.