### PR TITLE
fix: properly split buckets

### DIFF
--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -4,10 +4,10 @@
 //! decimal point.
 
 use az::{Az, Cast};
+use divrem::DivCeil;
 use fixed::traits::Fixed;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
-use divrem::DivCeil;
 
 #[cfg(feature = "serialize")]
 use crate::custom_serde::*;

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -2,10 +2,10 @@
 //! are floats. f64 or f32 are supported currently.
 
 use az::{Az, Cast};
+use divrem::DivCeil;
 use num_traits::Float;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
-use divrem::DivCeil;
 
 #[cfg(feature = "serialize")]
 use crate::custom_serde::*;

--- a/src/float/query/mod.rs
+++ b/src/float/query/mod.rs
@@ -3,3 +3,5 @@ pub mod nearest_n;
 pub mod nearest_one;
 pub mod within;
 pub mod within_unsorted;
+// pub mod query_macro;
+// pub mod nearest_n_mac;

--- a/src/float/query/within.rs
+++ b/src/float/query/within.rs
@@ -241,6 +241,9 @@ mod tests {
                 .map(|n| (n.distance, n.item))
                 .collect();
 
+            // TODO: ensure that adjacent results with the same dist are sorted in order of item val
+            //       to prevent occasional test failures due to the linear search returning items
+            //       with the same dist in a different order to the query
             assert_eq!(result, expected);
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 //! Definitions for some types that are common between the [`fixed`](crate::fixed) and [`float`](crate::float) modules
 use az::Cast;
+use divrem::DivCeil;
 use num_traits::{One, PrimInt, Unsigned, Zero};
 use std::fmt::Debug;
-use divrem::DivCeil;
 
 /// Content trait.
 ///


### PR DESCRIPTION
previously, when a bucket had multiple items with the same value in the splitting dimension as the split plane, and these values straddled the pivot point, some items could end up in the wrong bucket after the split.

Fixes: https://github.com/sdd/kiddo/issues/28
