### PR TITLE
Refactor all query methods into macros that are common between `fixed` and `float`

### DIFF
--- a/benches/nearest_n.rs
+++ b/benches/nearest_n.rs
@@ -85,6 +85,7 @@ fn perform_query_float_10<
 {
     kdtree
         .nearest_n(&point, 10, &squared_euclidean)
+        .into_iter()
         .for_each(|res_item| {
             black_box({
                 let _x = res_item;
@@ -107,6 +108,7 @@ fn perform_query_fixed_10<
 {
     kdtree
         .nearest_n(&point, 10, &squared_euclidean_fixedpoint)
+        .into_iter()
         .for_each(|res_item| {
             black_box({
                 let _x = res_item;
@@ -241,6 +243,7 @@ fn perform_query_float_100<
 {
     kdtree
         .nearest_n(&point, 100, &squared_euclidean)
+        .into_iter()
         .for_each(|res_item| {
             black_box({
                 let _x = res_item;
@@ -263,6 +266,7 @@ fn perform_query_fixed_100<
 {
     kdtree
         .nearest_n(&point, 100, &squared_euclidean_fixedpoint)
+        .into_iter()
         .for_each(|res_item| {
             black_box({
                 let _x = res_item;

--- a/examples/rkyv.rs
+++ b/examples/rkyv.rs
@@ -100,9 +100,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (_, nearest_idx) = mm_zc_deserialized_tree.nearest_one(&query, &squared_euclidean);
     let nearest = &cities[nearest_idx as usize];
     println!("Nearest city to 52.5N, 1.9W: {:?}", nearest);
-    println!("total elapsed: {}\n\n", ElapsedDuration::new(start.elapsed()));
-
-
+    println!(
+        "total elapsed: {}\n\n",
+        ElapsedDuration::new(start.elapsed())
+    );
 
     /////// zero-copy non-memmapped deserialization ////////////////////////////////
     let start = Instant::now();
@@ -118,8 +119,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (_, nearest_idx) = zc_deserialized_tree.nearest_one(&query, &squared_euclidean);
     let nearest = &cities[nearest_idx as usize];
     println!("Nearest city to 52.5N, 1.9W: {:?}", nearest);
-    println!("total elapsed: {}\n\n", ElapsedDuration::new(start.elapsed()));
-
+    println!(
+        "total elapsed: {}\n\n",
+        ElapsedDuration::new(start.elapsed())
+    );
 
     /////// non-zero-copy memmapped deserialization ////////////////////////////////
     let start = Instant::now();
@@ -135,10 +138,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (_, nearest_idx) = mm_deserialized_tree.nearest_one(&query, &squared_euclidean);
     let nearest = &cities[nearest_idx as usize];
     println!("Nearest city to 52.5N, 1.9W: {:?}", nearest);
-    println!("total elapsed: {}\n\n", ElapsedDuration::new(start.elapsed()));
-
-
-
+    println!(
+        "total elapsed: {}\n\n",
+        ElapsedDuration::new(start.elapsed())
+    );
 
     ///////// non-zero-copy, non-memmapped deserialization ///////////////////////
     let start = Instant::now();
@@ -156,8 +159,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (_, nearest_idx) = deserialized_tree.nearest_one(&query, &squared_euclidean);
     let nearest = &cities[nearest_idx as usize];
     println!("Nearest city to 52.5N, 1.9W: {:?}", nearest);
-    println!("total elapsed: {}\n\n", ElapsedDuration::new(start.elapsed()));
-
+    println!(
+        "total elapsed: {}\n\n",
+        ElapsedDuration::new(start.elapsed())
+    );
 
     Ok(())
 }

--- a/src/common/generate_best_n_within.rs
+++ b/src/common/generate_best_n_within.rs
@@ -1,0 +1,145 @@
+#[macro_export]
+macro_rules! generate_best_n_within {
+    ($leafnode:ident, $comments:tt) => {
+    doc_comment! {
+    concat!$comments,
+    #[inline]
+    pub fn best_n_within<F>(
+        &self,
+        query: &[A; K],
+        dist: A,
+        max_qty: usize,
+        distance_fn: &F,
+    ) -> impl Iterator<Item = T>
+    where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        let mut off = [A::zero(); K];
+        let mut best_items: BinaryHeap<T> = BinaryHeap::new();
+
+        unsafe {
+            self.best_n_within_recurse(
+                query,
+                dist,
+                max_qty,
+                distance_fn,
+                self.root_index,
+                0,
+                &mut best_items,
+                &mut off,
+                A::zero(),
+            );
+        }
+
+        best_items.into_iter()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn best_n_within_recurse<F>(
+        &self,
+        query: &[A; K],
+        radius: A,
+        max_qty: usize,
+        distance_fn: &F,
+        curr_node_idx: IDX,
+        split_dim: usize,
+        best_items: &mut BinaryHeap<T>,
+        off: &mut [A; K],
+        rd: A,
+    ) where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        if is_stem_index(curr_node_idx) {
+            let node = self.stems.get_unchecked(curr_node_idx.az::<usize>());
+
+            let mut rd = rd;
+            let old_off = off[split_dim];
+            let new_off = query[split_dim].saturating_dist(node.split_val);
+
+            let [closer_node_idx, further_node_idx] =
+                if *query.get_unchecked(split_dim) < node.split_val {
+                    [node.left, node.right]
+                } else {
+                    [node.right, node.left]
+                };
+            let next_split_dim = (split_dim + 1).rem(K);
+
+            self.best_n_within_recurse(
+                query,
+                radius,
+                max_qty,
+                distance_fn,
+                closer_node_idx,
+                next_split_dim,
+                best_items,
+                off,
+                rd,
+            );
+
+            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
+            //       so that updating rd is not hardcoded to sq euclidean
+            rd = rd.rd_update(old_off, new_off);
+
+            if rd <= radius {
+                off[split_dim] = new_off;
+                self.best_n_within_recurse(
+                    query,
+                    radius,
+                    max_qty,
+                    distance_fn,
+                    further_node_idx,
+                    next_split_dim,
+                    best_items,
+                    off,
+                    rd,
+                );
+                off[split_dim] = old_off;
+            }
+        } else {
+            let leaf_node = self
+                .leaves
+                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
+
+            Self::process_leaf_node(query, radius, max_qty, distance_fn, best_items, leaf_node);
+        }
+    }
+
+    unsafe fn process_leaf_node<F>(
+        query: &[A; K],
+        radius: A,
+        max_qty: usize,
+        distance_fn: &F,
+        best_items: &mut BinaryHeap<T>,
+        leaf_node: &$leafnode<A, T, K, B, IDX>,
+    ) where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        leaf_node
+            .content_points
+            .iter()
+            .take(leaf_node.size.az::<usize>())
+            .map(|entry| distance_fn(query, entry))
+            .enumerate()
+            .filter(|(_, distance)| *distance <= radius)
+            .for_each(|(idx, _)| {
+                Self::get_item_and_add_if_good(max_qty, best_items, leaf_node, idx)
+            });
+    }
+
+    unsafe fn get_item_and_add_if_good(
+        max_qty: usize,
+        best_items: &mut BinaryHeap<T>,
+        leaf_node: &$leafnode<A, T, K, B, IDX>,
+        idx: usize,
+    ) {
+        let item = *leaf_node.content_items.get_unchecked(idx.az::<usize>());
+        if best_items.len() < max_qty {
+            best_items.push(item);
+        } else {
+            let mut top = best_items.peek_mut().unwrap();
+            if item < *top {
+                *top = item;
+            }
+        }
+    }
+}}}

--- a/src/common/generate_nearest_n.rs
+++ b/src/common/generate_nearest_n.rs
@@ -1,0 +1,113 @@
+#[macro_export]
+macro_rules! generate_nearest_n {
+    ($comments:tt) => {
+    doc_comment! {
+    concat!$comments,
+    #[inline]
+    pub fn nearest_n<F>(&self, query: &[A; K], qty: usize, distance_fn: &F) -> Vec<Neighbour<A, T>>
+    where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        let mut off = [A::zero(); K];
+        let mut result: BinaryHeap<Neighbour<A, T>> = BinaryHeap::with_capacity(qty);
+
+        unsafe {
+            self.nearest_n_recurse(
+                query,
+                distance_fn,
+                self.root_index,
+                0,
+                &mut result,
+                &mut off,
+                A::zero(),
+            )
+        }
+
+        result.into_sorted_vec()
+    }
+
+    unsafe fn nearest_n_recurse<F>(
+        &self,
+        query: &[A; K],
+        distance_fn: &F,
+        curr_node_idx: IDX,
+        split_dim: usize,
+        results: &mut BinaryHeap<Neighbour<A, T>>,
+        off: &mut [A; K],
+        rd: A,
+    ) where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        if is_stem_index(curr_node_idx) {
+            let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
+
+            let mut rd = rd;
+            let old_off = off[split_dim];
+            let new_off = query[split_dim].saturating_dist(node.split_val);
+
+            let [closer_node_idx, further_node_idx] =
+                if *query.get_unchecked(split_dim) < node.split_val {
+                    [node.left, node.right]
+                } else {
+                    [node.right, node.left]
+                };
+            let next_split_dim = (split_dim + 1).rem(K);
+
+            self.nearest_n_recurse(
+                query,
+                distance_fn,
+                closer_node_idx,
+                next_split_dim,
+                results,
+                off,
+                rd,
+            );
+
+            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
+            //       so that updating rd is not hardcoded to sq euclidean
+            rd = rd.rd_update(old_off, new_off);
+            if Self::dist_belongs_in_heap(rd, results) {
+                off[split_dim] = new_off;
+                self.nearest_n_recurse(
+                    query,
+                    distance_fn,
+                    further_node_idx,
+                    next_split_dim,
+                    results,
+                    off,
+                    rd,
+                );
+                off[split_dim] = old_off;
+            }
+        } else {
+            let leaf_node = self
+                .leaves
+                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
+
+            leaf_node
+                .content_points
+                .iter()
+                .take(leaf_node.size.az::<usize>())
+                .enumerate()
+                .for_each(|(idx, entry)| {
+                    let distance: A = distance_fn(query, entry);
+                    if Self::dist_belongs_in_heap(distance, results) {
+                        let item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
+                        let element = Neighbour { distance, item };
+                        if results.len() < results.capacity() {
+                            results.push(element)
+                        } else {
+                            let mut top = results.peek_mut().unwrap();
+                            if element.distance < top.distance {
+                                *top = element;
+                            }
+                        }
+                    }
+                });
+        }
+    }
+
+    fn dist_belongs_in_heap(dist: A, heap: &BinaryHeap<Neighbour<A, T>>) -> bool {
+        heap.is_empty() || dist < heap.peek().unwrap().distance || heap.len() < heap.capacity()
+    }
+}}}

--- a/src/common/generate_nearest_one.rs
+++ b/src/common/generate_nearest_one.rs
@@ -1,133 +1,137 @@
 #[macro_export]
 macro_rules! generate_nearest_one {
-    ($kdtree:ident, $leafnode:ident, $comments:tt) => {
-    doc_comment! {
-    concat!$comments,
-    #[inline]
-    pub fn nearest_one<F>(&self, query: &[A; K], distance_fn: &F) -> (A, T)
-        where
-            F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::zero(); K];
-        unsafe {
-            self.nearest_one_recurse(
-                query,
-                distance_fn,
-                self.root_index,
-                0,
-                T::zero(),
-                A::max_value(),
-                &mut off,
-                A::zero(),
-            )
-        }
-    }
+    ($leafnode:ident, $comments:tt) => {
+        doc_comment! {
+            concat!$comments,
+            #[inline]
+            pub fn nearest_one<F>(&self, query: &[A; K], distance_fn: &F) -> (A, T)
+                where
+                    F: Fn(&[A; K], &[A; K]) -> A,
+            {
+                let mut off = [A::zero(); K];
 
-    #[inline]
-    unsafe fn nearest_one_recurse<F>(
-        &self,
-        query: &[A; K],
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        mut best_item: T,
-        mut best_dist: A,
-        off: &mut [A; K],
-        rd: A,
-    ) -> (A, T)
-        where
-            F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
+                unsafe {
+                    self.nearest_one_recurse(
+                        query,
+                        distance_fn,
+                        self.root_index,
+                        0,
+                        T::zero(),
+                        A::max_value(),
+                        &mut off,
+                        A::zero(),
+                    )
+                }
+            }
 
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim].saturating_dist(node.split_val);
+            #[inline]
+            unsafe fn nearest_one_recurse<F>(
+                &self,
+                query: &[A; K],
+                distance_fn: &F,
+                curr_node_idx: IDX,
+                split_dim: usize,
+                mut best_item: T,
+                mut best_dist: A,
+                off: &mut [A; K],
+                rd: A,
+            ) -> (A, T)
+                where
+                    F: Fn(&[A; K], &[A; K]) -> A,
+            {
+                if is_stem_index(curr_node_idx) {
+                    let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
 
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
+                    let mut rd = rd;
+                    let old_off = off[split_dim];
+                    let new_off = query[split_dim].saturating_dist(node.split_val);
+
+                    let [closer_node_idx, further_node_idx] =
+                        if *query.get_unchecked(split_dim) < node.split_val {
+                            [node.left, node.right]
+                        } else {
+                            [node.right, node.left]
+                        };
+                    let next_split_dim = (split_dim + 1).rem(K);
+
+                    let (dist, item) = self.nearest_one_recurse(
+                        query,
+                        distance_fn,
+                        closer_node_idx,
+                        next_split_dim,
+                        best_item,
+                        best_dist,
+                        off,
+                        rd,
+                    );
+
+                    if dist < best_dist {
+                        best_dist = dist;
+                        best_item = item;
+                    }
+
+                    // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
+                    //       so that updating rd is not hardcoded to sq euclidean
+                    rd = rd.rd_update(old_off, new_off);
+                    if rd <= best_dist {
+                        off[split_dim] = new_off;
+                        let (dist, item) = self.nearest_one_recurse(
+                            query,
+                            distance_fn,
+                            further_node_idx,
+                            next_split_dim,
+                            best_item,
+                            best_dist,
+                            off,
+                            rd,
+                        );
+                        off[split_dim] = old_off;
+
+                        if dist < best_dist {
+                            best_dist = dist;
+                            best_item = item;
+                        }
+                    }
                 } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
+                    let leaf_node = self
+                        .leaves
+                        .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
 
-            let (dist, item) = self.nearest_one_recurse(
-                query,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                best_item,
-                best_dist,
-                off,
-                rd,
-            );
-
-            if dist < best_dist {
-                best_dist = dist;
-                best_item = item;
-            }
-
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd.rd_update(old_off, new_off);
-            if rd <= best_dist {
-                off[split_dim] = new_off;
-                let (dist, item) = self.nearest_one_recurse(
-                    query,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    best_item,
-                    best_dist,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-
-                if dist < best_dist {
-                    best_dist = dist;
-                    best_item = item;
+                    Self::search_content_for_best(
+                        query,
+                        distance_fn,
+                        &mut best_item,
+                        &mut best_dist,
+                        leaf_node,
+                    );
                 }
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
 
-            Self::search_content_for_best(
-                query,
-                distance_fn,
-                &mut best_item,
-                &mut best_dist,
-                leaf_node,
-            );
+                (best_dist, best_item)
+            }
+
+            #[inline]
+            fn search_content_for_best<F>(
+                query: &[A; K],
+                distance_fn: &F,
+                best_item: &mut T,
+                best_dist: &mut A,
+                leaf_node: &$leafnode<A, T, K, B, IDX>,
+            ) where
+                F: Fn(&[A; K], &[A; K]) -> A,
+            {
+                leaf_node
+                    .content_points
+                    .iter()
+                    .enumerate()
+                    .take(leaf_node.size.az::<usize>())
+                    .for_each(|(idx, entry)| {
+                        let dist = distance_fn(query, entry);
+                        if dist < *best_dist {
+                            *best_dist = dist;
+                            *best_item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
+                        }
+                    });
+            }
         }
-
-        (best_dist, best_item)
-    }
-
-    fn search_content_for_best<F>(
-        query: &[A; K],
-        distance_fn: &F,
-        best_item: &mut T,
-        best_dist: &mut A,
-        leaf_node: &$leafnode<A, T, K, B, IDX>,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        leaf_node
-            .content_points
-            .iter()
-            .enumerate()
-            .take(leaf_node.size.az::<usize>())
-            .for_each(|(idx, entry)| {
-                let dist = distance_fn(query, entry);
-                if dist < *best_dist {
-                    *best_dist = dist;
-                    *best_item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
-                }
-            });
-    }
-}}}
+    };
+}

--- a/src/common/generate_nearest_one.rs
+++ b/src/common/generate_nearest_one.rs
@@ -1,0 +1,133 @@
+#[macro_export]
+macro_rules! generate_nearest_one {
+    ($kdtree:ident, $leafnode:ident, $comments:tt) => {
+    doc_comment! {
+    concat!$comments,
+    #[inline]
+    pub fn nearest_one<F>(&self, query: &[A; K], distance_fn: &F) -> (A, T)
+        where
+            F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        let mut off = [A::zero(); K];
+        unsafe {
+            self.nearest_one_recurse(
+                query,
+                distance_fn,
+                self.root_index,
+                0,
+                T::zero(),
+                A::max_value(),
+                &mut off,
+                A::zero(),
+            )
+        }
+    }
+
+    #[inline]
+    unsafe fn nearest_one_recurse<F>(
+        &self,
+        query: &[A; K],
+        distance_fn: &F,
+        curr_node_idx: IDX,
+        split_dim: usize,
+        mut best_item: T,
+        mut best_dist: A,
+        off: &mut [A; K],
+        rd: A,
+    ) -> (A, T)
+        where
+            F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
+            let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
+
+            let mut rd = rd;
+            let old_off = off[split_dim];
+            let new_off = query[split_dim].saturating_dist(node.split_val);
+
+            let [closer_node_idx, further_node_idx] =
+                if *query.get_unchecked(split_dim) < node.split_val {
+                    [node.left, node.right]
+                } else {
+                    [node.right, node.left]
+                };
+            let next_split_dim = (split_dim + 1).rem(K);
+
+            let (dist, item) = self.nearest_one_recurse(
+                query,
+                distance_fn,
+                closer_node_idx,
+                next_split_dim,
+                best_item,
+                best_dist,
+                off,
+                rd,
+            );
+
+            if dist < best_dist {
+                best_dist = dist;
+                best_item = item;
+            }
+
+            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
+            //       so that updating rd is not hardcoded to sq euclidean
+            rd = rd.rd_update(old_off, new_off);
+            if rd <= best_dist {
+                off[split_dim] = new_off;
+                let (dist, item) = self.nearest_one_recurse(
+                    query,
+                    distance_fn,
+                    further_node_idx,
+                    next_split_dim,
+                    best_item,
+                    best_dist,
+                    off,
+                    rd,
+                );
+                off[split_dim] = old_off;
+
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_item = item;
+                }
+            }
+        } else {
+            let leaf_node = self
+                .leaves
+                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
+
+            Self::search_content_for_best(
+                query,
+                distance_fn,
+                &mut best_item,
+                &mut best_dist,
+                leaf_node,
+            );
+        }
+
+        (best_dist, best_item)
+    }
+
+    fn search_content_for_best<F>(
+        query: &[A; K],
+        distance_fn: &F,
+        best_item: &mut T,
+        best_dist: &mut A,
+        leaf_node: &$leafnode<A, T, K, B, IDX>,
+    ) where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        leaf_node
+            .content_points
+            .iter()
+            .enumerate()
+            .take(leaf_node.size.az::<usize>())
+            .for_each(|(idx, entry)| {
+                let dist = distance_fn(query, entry);
+                if dist < *best_dist {
+                    *best_dist = dist;
+                    *best_item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
+                }
+            });
+    }
+}}}

--- a/src/common/generate_within.rs
+++ b/src/common/generate_within.rs
@@ -1,0 +1,109 @@
+#[macro_export]
+macro_rules! generate_within {
+    ($comments:tt) => {
+    doc_comment! {
+    concat!$comments,
+    #[inline]
+    pub fn within<F>(&self, query: &[A; K], dist: A, distance_fn: &F) -> Vec<Neighbour<A, T>>
+    where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        let mut off = [A::zero(); K];
+        let mut matching_items: BinaryHeap<Neighbour<A, T>> = BinaryHeap::new();
+
+        unsafe {
+            self.within_recurse(
+                query,
+                dist,
+                distance_fn,
+                self.root_index,
+                0,
+                &mut matching_items,
+                &mut off,
+                A::zero(),
+            );
+        }
+
+        matching_items.into_sorted_vec()
+    }
+
+    unsafe fn within_recurse<F>(
+        &self,
+        query: &[A; K],
+        radius: A,
+        distance_fn: &F,
+        curr_node_idx: IDX,
+        split_dim: usize,
+        matching_items: &mut BinaryHeap<Neighbour<A, T>>,
+        off: &mut [A; K],
+        rd: A,
+    ) where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        if is_stem_index(curr_node_idx) {
+            let node = self.stems.get_unchecked(curr_node_idx.az::<usize>());
+
+            let mut rd = rd;
+            let old_off = off[split_dim];
+            let new_off = query[split_dim].saturating_dist(node.split_val);
+
+            let [closer_node_idx, further_node_idx] =
+                if *query.get_unchecked(split_dim) < node.split_val {
+                    [node.left, node.right]
+                } else {
+                    [node.right, node.left]
+                };
+            let next_split_dim = (split_dim + 1).rem(K);
+
+            self.within_recurse(
+                query,
+                radius,
+                distance_fn,
+                closer_node_idx,
+                next_split_dim,
+                matching_items,
+                off,
+                rd,
+            );
+
+            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
+            //       so that updating rd is not hardcoded to sq euclidean
+            rd = rd.rd_update(old_off, new_off);
+
+            if rd <= radius {
+                off[split_dim] = new_off;
+                self.within_recurse(
+                    query,
+                    radius,
+                    distance_fn,
+                    further_node_idx,
+                    next_split_dim,
+                    matching_items,
+                    off,
+                    rd,
+                );
+                off[split_dim] = old_off;
+            }
+        } else {
+            let leaf_node = self
+                .leaves
+                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
+
+            leaf_node
+                .content_points
+                .iter()
+                .enumerate()
+                .take(leaf_node.size.az::<usize>())
+                .for_each(|(idx, entry)| {
+                    let distance = distance_fn(query, entry);
+
+                    if distance < radius {
+                        matching_items.push(Neighbour {
+                            distance,
+                            item: *leaf_node.content_items.get_unchecked(idx.az::<usize>()),
+                        })
+                    }
+                });
+        }
+    }
+}}}

--- a/src/common/generate_within_unsorted.rs
+++ b/src/common/generate_within_unsorted.rs
@@ -1,0 +1,109 @@
+#[macro_export]
+macro_rules! generate_within_unsorted {
+    ($comments:tt) => {
+    doc_comment! {
+    concat!$comments,
+    #[inline]
+    pub fn within_unsorted<F>(&self, query: &[A; K], dist: A, distance_fn: &F) -> Vec<Neighbour<A, T>>
+    where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        let mut off = [A::zero(); K];
+        let mut matching_items = Vec::new();
+
+        unsafe {
+            self.within_unsorted_recurse(
+                query,
+                dist,
+                distance_fn,
+                self.root_index,
+                0,
+                &mut matching_items,
+                &mut off,
+                A::zero(),
+            );
+        }
+
+        matching_items
+    }
+
+    unsafe fn within_unsorted_recurse<F>(
+        &self,
+        query: &[A; K],
+        radius: A,
+        distance_fn: &F,
+        curr_node_idx: IDX,
+        split_dim: usize,
+        matching_items: &mut Vec<Neighbour<A, T>>,
+        off: &mut [A; K],
+        rd: A,
+    ) where
+        F: Fn(&[A; K], &[A; K]) -> A,
+    {
+        if is_stem_index(curr_node_idx) {
+            let node = self.stems.get_unchecked(curr_node_idx.az::<usize>());
+
+            let mut rd = rd;
+            let old_off = off[split_dim];
+            let new_off = query[split_dim].saturating_dist(node.split_val);
+
+            let [closer_node_idx, further_node_idx] =
+                if *query.get_unchecked(split_dim) < node.split_val {
+                    [node.left, node.right]
+                } else {
+                    [node.right, node.left]
+                };
+            let next_split_dim = (split_dim + 1).rem(K);
+
+            self.within_unsorted_recurse(
+                query,
+                radius,
+                distance_fn,
+                closer_node_idx,
+                next_split_dim,
+                matching_items,
+                off,
+                rd,
+            );
+
+            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
+            //       so that updating rd is not hardcoded to sq euclidean
+            rd = rd.rd_update(old_off, new_off);
+
+            if rd <= radius {
+                off[split_dim] = new_off;
+                self.within_unsorted_recurse(
+                    query,
+                    radius,
+                    distance_fn,
+                    further_node_idx,
+                    next_split_dim,
+                    matching_items,
+                    off,
+                    rd,
+                );
+                off[split_dim] = old_off;
+            }
+        } else {
+            let leaf_node = self
+                .leaves
+                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
+
+            leaf_node
+                .content_points
+                .iter()
+                .enumerate()
+                .take(leaf_node.size.az::<usize>())
+                .for_each(|(idx, entry)| {
+                    let distance = distance_fn(query, entry);
+
+                    if distance < radius {
+                        matching_items.push(Neighbour {
+                            distance,
+                            item: *leaf_node.content_items.get_unchecked(idx.az::<usize>()),
+                        })
+                    }
+                });
+        }
+    }
+}}}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod generate_nearest_n;
 pub(crate) mod generate_nearest_one;
+pub(crate) mod generate_within;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod generate_nearest_one;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod generate_nearest_n;
 pub(crate) mod generate_nearest_one;
 pub(crate) mod generate_within;
+pub(crate) mod generate_within_unsorted;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod generate_nearest_n;
 pub(crate) mod generate_nearest_one;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod generate_best_n_within;
 pub(crate) mod generate_nearest_n;
 pub(crate) mod generate_nearest_one;
 pub(crate) mod generate_within;

--- a/src/fixed/construction.rs
+++ b/src/fixed/construction.rs
@@ -1,6 +1,6 @@
 use crate::fixed::kdtree::{Axis, KdTree, LeafNode, StemNode};
 use crate::mirror_select_nth_unstable_by::mirror_select_nth_unstable_by;
-use crate::types::{Content, Index};
+use crate::types::{is_stem_index, Content, Index};
 use az::{Az, Cast};
 use std::ops::Rem;
 
@@ -39,7 +39,7 @@ where
             let mut parent_idx = <IDX as Index>::max();
             let mut is_left_child: bool = false;
 
-            while KdTree::<A, T, K, B, IDX>::is_stem_index(stem_idx) {
+            while is_stem_index(stem_idx) {
                 parent_idx = stem_idx;
                 stem_node = self.stems.get_unchecked_mut(stem_idx.az::<usize>());
 
@@ -114,7 +114,7 @@ where
         let mut split_dim = 0;
         let mut removed: usize = 0;
 
-        while KdTree::<A, T, K, B, IDX>::is_stem_index(stem_idx) {
+        while is_stem_index(stem_idx) {
             let Some(stem_node) = self.stems.get_mut(stem_idx.az::<usize>()) else {
                 return removed;
             };

--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -22,8 +22,7 @@ use serde::{Deserialize, Serialize};
 pub trait Axis: Fixed + Default + Debug + Copy + Sync {
     fn max_value() -> Self;
     fn zero() -> Self;
-    fn rd_update(self, old_off: Self,  new_off: Self) -> Self;
-
+    fn rd_update(self, old_off: Self, new_off: Self) -> Self;
 }
 impl<T: Fixed + Default + Debug + Copy + Sync> Axis for T {
     fn max_value() -> Self {
@@ -36,7 +35,7 @@ impl<T: Fixed + Default + Debug + Copy + Sync> Axis for T {
 
     fn rd_update(self, old_off: Self, new_off: Self) -> Self {
         self.saturating_add(
-            (new_off.saturating_mul(new_off)).saturating_sub(old_off.saturating_mul(old_off))
+            (new_off.saturating_mul(new_off)).saturating_sub(old_off.saturating_mul(old_off)),
         )
     }
 }

--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -20,8 +20,11 @@ use serde::{Deserialize, Serialize};
 /// on `KdTree`. A type from the `Fixed` crate will implement
 /// all of the traits required by Axis. For example `FixedU16<U14>`.
 pub trait Axis: Fixed + Default + Debug + Copy + Sync {
+    /// Returns the maximum value that the type implementing this trait can have
     fn max_value() -> Self;
+    /// returns the zero value for this type
     fn zero() -> Self;
+    /// used within query functions to update rd from old and new off
     fn rd_update(self, old_off: Self, new_off: Self) -> Self;
 }
 impl<T: Fixed + Default + Debug + Copy + Sync> Axis for T {
@@ -249,10 +252,6 @@ where
     #[inline]
     pub fn size(&self) -> T {
         self.size
-    }
-
-    pub(crate) fn is_stem_index(x: IDX) -> bool {
-        x < <IDX as Index>::leaf_offset()
     }
 }
 

--- a/src/fixed/query/nearest_n.rs
+++ b/src/fixed/query/nearest_n.rs
@@ -1,149 +1,44 @@
-use crate::fixed::kdtree::{Axis, KdTree};
-use crate::fixed::neighbour::Neighbour;
-use crate::types::{Content, Index};
 use az::{Az, Cast};
 use std::collections::BinaryHeap;
 use std::ops::Rem;
+
+use crate::fixed::kdtree::{Axis, KdTree};
+use crate::fixed::neighbour::Neighbour;
+use crate::types::{Content, Index, is_stem_index};
+
+use crate::generate_nearest_n;
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    /// Finds the nearest `qty` elements to `query`, using the specified
-    /// distance metric function.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use fixed::FixedU16;
-    /// use fixed::types::extra::U0;
-    /// use kiddo::fixed::kdtree::KdTree;
-    /// use kiddo::fixed::distance::squared_euclidean;
-    ///
-    /// type FXD = FixedU16<U0>;
-    ///
-    /// let mut tree: KdTree<FXD, u32, 3, 32, u32> = KdTree::new();
-    ///
-    /// tree.add(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], 100);
-    /// tree.add(&[FXD::from_num(2), FXD::from_num(3), FXD::from_num(6)], 101);
-    ///
-    /// let nearest: Vec<_> = tree.nearest_n(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], 1, &squared_euclidean);
-    ///
-    /// assert_eq!(nearest.len(), 1);
-    /// assert_eq!(nearest[0].distance, FXD::from_num(0));
-    /// assert_eq!(nearest[0].item, 100);
-    /// ```
-    #[inline]
-    pub fn nearest_n<F>(&self, query: &[A; K], qty: usize, distance_fn: &F) -> Vec<Neighbour<A, T>>
-    where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::ZERO; K];
-        let mut result: BinaryHeap<Neighbour<A, T>> = BinaryHeap::with_capacity(qty);
+    generate_nearest_n!(
+        (r#"Finds the nearest `qty` elements to `query`, using the specified
+distance metric function.
 
-        unsafe {
-            self.nearest_n_recurse(
-                query,
-                distance_fn,
-                self.root_index,
-                0,
-                &mut result,
-                &mut off,
-                A::ZERO,
-            )
-        }
+# Examples
 
-        result.into_sorted_vec()
-    }
+```rust
+    use fixed::FixedU16;
+    use fixed::types::extra::U0;
+    use kiddo::fixed::kdtree::KdTree;
+    use kiddo::fixed::distance::squared_euclidean;
 
-    unsafe fn nearest_n_recurse<F>(
-        &self,
-        query: &[A; K],
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        results: &mut BinaryHeap<Neighbour<A, T>>,
-        off: &mut [A; K],
-        rd: A,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
+    type FXD = FixedU16<U0>;
 
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim].dist(node.split_val);
+    let mut tree: KdTree<FXD, u32, 3, 32, u32> = KdTree::new();
 
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
-                } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
+    tree.add(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], 100);
+    tree.add(&[FXD::from_num(2), FXD::from_num(3), FXD::from_num(6)], 101);
 
-            self.nearest_n_recurse(
-                query,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                results,
-                off,
-                rd,
-            );
+    let nearest: Vec<_> = tree.nearest_n(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], 1, &squared_euclidean);
 
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd.saturating_add(
-                (new_off.saturating_mul(new_off)).saturating_sub(old_off.saturating_mul(old_off)),
-            );
-
-            if Self::dist_belongs_in_heap(rd, results) {
-                off[split_dim] = new_off;
-                self.nearest_n_recurse(
-                    query,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    results,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
-
-            leaf_node
-                .content_points
-                .iter()
-                .take(leaf_node.size.az::<usize>())
-                .enumerate()
-                .for_each(|(idx, entry)| {
-                    let distance: A = distance_fn(query, entry);
-                    if Self::dist_belongs_in_heap(distance, results) {
-                        let item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
-                        let element = Neighbour { distance, item };
-                        if results.len() < results.capacity() {
-                            results.push(element)
-                        } else {
-                            let mut top = results.peek_mut().unwrap();
-                            if element.distance < top.distance {
-                                *top = element;
-                            }
-                        }
-                    }
-                });
-        }
-    }
-
-    fn dist_belongs_in_heap(dist: A, heap: &BinaryHeap<Neighbour<A, T>>) -> bool {
-        heap.is_empty() || dist < heap.peek().unwrap().distance || heap.len() < heap.capacity()
-    }
+    assert_eq!(nearest.len(), 1);
+    assert_eq!(nearest[0].distance, FXD::from_num(0));
+    assert_eq!(nearest[0].item, 100);
+```"#)
+    );
 }
 
 #[cfg(test)]

--- a/src/fixed/query/nearest_n.rs
+++ b/src/fixed/query/nearest_n.rs
@@ -4,7 +4,7 @@ use std::ops::Rem;
 
 use crate::fixed::kdtree::{Axis, KdTree};
 use crate::fixed::neighbour::Neighbour;
-use crate::types::{Content, Index, is_stem_index};
+use crate::types::{is_stem_index, Content, Index};
 
 use crate::generate_nearest_n;
 

--- a/src/fixed/query/nearest_one.rs
+++ b/src/fixed/query/nearest_one.rs
@@ -2,7 +2,7 @@ use az::{Az, Cast};
 use std::ops::Rem;
 
 use crate::fixed::kdtree::{Axis, KdTree, LeafNode};
-use crate::types::{Content, Index};
+use crate::types::{Content, Index, is_stem_index};
 
 use crate::generate_nearest_one;
 
@@ -12,7 +12,6 @@ where
     usize: Cast<IDX>,
 {
     generate_nearest_one!(
-        KdTree,
         LeafNode,
         (r#"Queries the tree to find the nearest element to `query`, using the specified
 distance metric function.
@@ -39,7 +38,8 @@ to not needing to allocate memory or maintain sorted results.
 
     assert_eq!(nearest.0, FXD::from_num(0));
     assert_eq!(nearest.1, 100);
-```"#));
+```"#)
+    );
 }
 
 #[cfg(test)]

--- a/src/fixed/query/nearest_one.rs
+++ b/src/fixed/query/nearest_one.rs
@@ -2,7 +2,7 @@ use az::{Az, Cast};
 use std::ops::Rem;
 
 use crate::fixed::kdtree::{Axis, KdTree, LeafNode};
-use crate::types::{Content, Index, is_stem_index};
+use crate::types::{is_stem_index, Content, Index};
 
 use crate::generate_nearest_one;
 

--- a/src/fixed/query/within_unsorted.rs
+++ b/src/fixed/query/within_unsorted.rs
@@ -3,150 +3,43 @@ use std::ops::Rem;
 
 use crate::fixed::kdtree::{Axis, KdTree};
 use crate::fixed::neighbour::Neighbour;
-use crate::types::{Content, Index};
+use crate::types::{is_stem_index, Content, Index};
+
+use crate::generate_within_unsorted;
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    /// Finds all elements within `dist` of `query`, using the specified
-    /// distance metric function.
-    ///
-    /// Results are returned in arbitrary order. Faster than `within`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use fixed::FixedU16;
-    /// use fixed::types::extra::U0;
-    /// use kiddo::fixed::kdtree::KdTree;
-    /// use kiddo::fixed::distance::squared_euclidean;
-    ///
-    /// type FXD = FixedU16<U0>;
+    generate_within_unsorted!(
+        (r#"Finds all elements within `dist` of `query`, using the specified
+distance metric function.
 
-    ///
-    /// let mut tree: KdTree<FXD, u32, 3, 32, u32> = KdTree::new();
-    ///
-    /// tree.add(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], 100);
-    /// tree.add(&[FXD::from_num(2), FXD::from_num(3), FXD::from_num(6)], 101);
-    /// tree.add(&[FXD::from_num(20), FXD::from_num(30), FXD::from_num(60)], 102);
-    ///
-    /// let within = tree.within(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], FXD::from_num(10), &squared_euclidean);
-    ///
-    /// assert_eq!(within.len(), 2);
-    /// ```
-    #[inline]
-    pub fn within_unsorted<F>(
-        &self,
-        query: &[A; K],
-        dist: A,
-        distance_fn: &F,
-    ) -> Vec<Neighbour<A, T>>
-    where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::ZERO; K];
-        let mut matching_items = Vec::with_capacity(32_000);
+Results are returned in arbitrary order. Faster than `within`.
 
-        unsafe {
-            self.within_unsorted_recurse(
-                query,
-                dist,
-                distance_fn,
-                self.root_index,
-                0,
-                &mut matching_items,
-                &mut off,
-                A::ZERO,
-            );
-        }
+# Examples
 
-        matching_items
-    }
+```rust
+    use fixed::FixedU16;
+    use fixed::types::extra::U0;
+    use kiddo::fixed::kdtree::KdTree;
+    use kiddo::fixed::distance::squared_euclidean;
 
-    unsafe fn within_unsorted_recurse<F>(
-        &self,
-        query: &[A; K],
-        radius: A,
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        matching_items: &mut Vec<Neighbour<A, T>>,
-        off: &mut [A; K],
-        rd: A,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = self.stems.get_unchecked(curr_node_idx.az::<usize>());
+    type FXD = FixedU16<U0>;
 
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim].dist(node.split_val);
 
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
-                } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
+    let mut tree: KdTree<FXD, u32, 3, 32, u32> = KdTree::new();
 
-            self.within_unsorted_recurse(
-                query,
-                radius,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                matching_items,
-                off,
-                rd,
-            );
+    tree.add(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], 100);
+    tree.add(&[FXD::from_num(2), FXD::from_num(3), FXD::from_num(6)], 101);
+    tree.add(&[FXD::from_num(20), FXD::from_num(30), FXD::from_num(60)], 102);
 
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd.saturating_add(
-                (new_off.saturating_mul(new_off)).saturating_sub(old_off.saturating_mul(old_off)),
-            );
+    let within = tree.within(&[FXD::from_num(1), FXD::from_num(2), FXD::from_num(5)], FXD::from_num(10), &squared_euclidean);
 
-            if rd <= radius {
-                off[split_dim] = new_off;
-                self.within_unsorted_recurse(
-                    query,
-                    radius,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    matching_items,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
-            // println!("Leaf node: {:?}", (curr_node_idx - LEAF_OFFSET) as usize);
-
-            leaf_node
-                .content_points
-                .iter()
-                .enumerate()
-                .take(leaf_node.size.az::<usize>())
-                .for_each(|(idx, entry)| {
-                    let distance = distance_fn(query, entry);
-
-                    if distance < radius {
-                        matching_items.push(Neighbour {
-                            distance,
-                            item: *leaf_node.content_items.get_unchecked(idx.az::<usize>()),
-                        });
-                    }
-                });
-        }
-    }
+    assert_eq!(within.len(), 2);
+```"#)
+    );
 }
 
 #[cfg(test)]

--- a/src/float/construction.rs
+++ b/src/float/construction.rs
@@ -1,6 +1,6 @@
 use crate::float::kdtree::{Axis, KdTree, LeafNode, StemNode};
 use crate::mirror_select_nth_unstable_by::mirror_select_nth_unstable_by;
-use crate::types::{Content, Index};
+use crate::types::{is_stem_index, Content, Index};
 use az::{Az, Cast};
 use std::ops::Rem;
 
@@ -34,7 +34,7 @@ where
             let mut parent_idx = <IDX as Index>::max();
             let mut is_left_child: bool = false;
 
-            while KdTree::<A, T, K, B, IDX>::is_stem_index(stem_idx) {
+            while is_stem_index(stem_idx) {
                 parent_idx = stem_idx;
                 stem_node = self.stems.get_unchecked_mut(stem_idx.az::<usize>());
 
@@ -105,7 +105,7 @@ where
         let mut split_dim = 0;
         let mut removed: usize = 0;
 
-        while KdTree::<A, T, K, B, IDX>::is_stem_index(stem_idx) {
+        while is_stem_index(stem_idx) {
             let Some(stem_node) = self.stems.get_mut(stem_idx.az::<usize>()) else {
                 return removed;
             };

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -16,8 +16,20 @@ use serde::{Deserialize, Serialize};
 /// Axis trait represents the traits that must be implemented
 /// by the type that is used as the first generic parameter, `A`,
 /// on the float `KdTree`. This will be `f64` or `f32`.
-pub trait Axis: Float + Default + Debug + Copy + Sync {}
-impl<T: Float + Default + Debug + Copy + Sync> Axis for T {}
+pub trait Axis: Float + Default + Debug + Copy + Sync {
+    fn saturating_dist(self, other: Self) -> Self;
+
+    fn rd_update(self, old_off: Self,  new_off: Self) -> Self;
+}
+impl<T: Float + Default + Debug + Copy + Sync> Axis for T {
+    fn saturating_dist(self, other: Self) -> Self {
+        (self - other).abs()
+    }
+
+    fn rd_update(self, old_off: Self,  new_off: Self) -> Self {
+        self + new_off * new_off - old_off * old_off
+    }
+}
 
 /// Floating point k-d tree
 ///

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -19,14 +19,14 @@ use serde::{Deserialize, Serialize};
 pub trait Axis: Float + Default + Debug + Copy + Sync {
     fn saturating_dist(self, other: Self) -> Self;
 
-    fn rd_update(self, old_off: Self,  new_off: Self) -> Self;
+    fn rd_update(self, old_off: Self, new_off: Self) -> Self;
 }
 impl<T: Float + Default + Debug + Copy + Sync> Axis for T {
     fn saturating_dist(self, other: Self) -> Self {
         (self - other).abs()
     }
 
-    fn rd_update(self, old_off: Self,  new_off: Self) -> Self {
+    fn rd_update(self, old_off: Self, new_off: Self) -> Self {
         self + new_off * new_off - old_off * old_off
     }
 }
@@ -181,29 +181,29 @@ where
 
 macro_rules! generate_common_methods {
     ($kdtree:ident) => {
-    /// Returns the current number of elements stored in the tree
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use kiddo::float::kdtree::KdTree;
-    ///
-    /// let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
-    ///
-    /// tree.add(&[1.0, 2.0, 5.0], 100);
-    /// tree.add(&[1.1, 2.1, 5.1], 101);
-    ///
-    /// assert_eq!(tree.size(), 2);
-    /// ```
-    #[inline]
-    pub fn size(&self) -> T {
-        self.size
-    }
+        /// Returns the current number of elements stored in the tree
+        ///
+        /// # Examples
+        ///
+        /// ```rust
+        /// use kiddo::float::kdtree::KdTree;
+        ///
+        /// let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
+        ///
+        /// tree.add(&[1.0, 2.0, 5.0], 100);
+        /// tree.add(&[1.1, 2.1, 5.1], 101);
+        ///
+        /// assert_eq!(tree.size(), 2);
+        /// ```
+        #[inline]
+        pub fn size(&self) -> T {
+            self.size
+        }
 
-    pub(crate) fn is_stem_index(x: IDX) -> bool {
-        x < <IDX as Index>::leaf_offset()
-    }
-    }
+        pub(crate) fn is_stem_index(x: IDX) -> bool {
+            x < <IDX as Index>::leaf_offset()
+        }
+    };
 }
 
 impl<A, T, const K: usize, const B: usize, IDX> KdTree<A, T, K, B, IDX>
@@ -216,12 +216,16 @@ where
     generate_common_methods!(KdTree);
 }
 
-
 #[cfg(feature = "rkyv")]
-impl<A: Axis + rkyv::Archive<Archived = A>, T: Content + rkyv::Archive<Archived = T>, const K: usize, const B: usize, IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>>
-ArchivedKdTree<A, T, K, B, IDX>
-    where
-        usize: Cast<IDX>,
+impl<
+        A: Axis + rkyv::Archive<Archived = A>,
+        T: Content + rkyv::Archive<Archived = T>,
+        const K: usize,
+        const B: usize,
+        IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>,
+    > ArchivedKdTree<A, T, K, B, IDX>
+where
+    usize: Cast<IDX>,
 {
     generate_common_methods!(ArchivedKdTree);
 }

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -17,8 +17,10 @@ use serde::{Deserialize, Serialize};
 /// by the type that is used as the first generic parameter, `A`,
 /// on the float `KdTree`. This will be `f64` or `f32`.
 pub trait Axis: Float + Default + Debug + Copy + Sync {
+    /// returns absolute diff between two values of a type implementing this trait
     fn saturating_dist(self, other: Self) -> Self;
 
+    /// used within query functions to update rd from old and new off
     fn rd_update(self, old_off: Self, new_off: Self) -> Self;
 }
 impl<T: Float + Default + Debug + Copy + Sync> Axis for T {
@@ -30,6 +32,15 @@ impl<T: Float + Default + Debug + Copy + Sync> Axis for T {
         self + new_off * new_off - old_off * old_off
     }
 }
+
+// TODO: make LeafNode and StemNode `pub(crate)` so that they,
+//       and their Archived types, don't show up in docs.
+//       This is tricky due to encountering this problem:
+//       https://github.com/rkyv/rkyv/issues/275
+/* #[cfg_attr(
+    feature = "serialize_rkyv",
+    omit_bounds
+)] */
 
 /// Floating point k-d tree
 ///
@@ -198,10 +209,6 @@ macro_rules! generate_common_methods {
         #[inline]
         pub fn size(&self) -> T {
             self.size
-        }
-
-        pub(crate) fn is_stem_index(x: IDX) -> bool {
-            x < <IDX as Index>::leaf_offset()
         }
     };
 }

--- a/src/float/query/best_n_within.rs
+++ b/src/float/query/best_n_within.rs
@@ -1,14 +1,18 @@
 use crate::float::kdtree::{Axis, KdTree, LeafNode};
 
-use crate::types::{Content, Index};
+use crate::types::{is_stem_index, Content, Index};
 use az::{Az, Cast};
 use std::collections::BinaryHeap;
 use std::ops::Rem;
 
-macro_rules! generate_best_n_within {
-        ($kdtree:ident, $leafnode:ident, $doctest_build_tree:tt) => {
-        doc_comment! {
-        concat!("Finds the \"best\" `n` elements within `dist` of `query`.
+use crate::generate_best_n_within;
+
+macro_rules! generate_float_best_n_within {
+    ($leafnode:ident, $doctest_build_tree:tt) => {
+        generate_best_n_within!(
+            $leafnode,
+            (
+                "Finds the \"best\" `n` elements within `dist` of `query`.
 
 Results are returned in arbitrary order. 'Best' is determined by
 performing a comparison of the elements using < (ie, std::ord::lt).
@@ -20,161 +24,26 @@ Returns an iterator.
     use kiddo::float::kdtree::KdTree;
     use kiddo::distance::squared_euclidean;
 
-    ",  $doctest_build_tree, "
+    ",
+                $doctest_build_tree,
+                "
 
     let mut best_n_within = tree.best_n_within(&[1.0, 2.0, 5.0], 10f64, 1, &squared_euclidean);
     let first = best_n_within.next().unwrap();
 
     assert_eq!(first, 100);
-```"),
-    #[inline]
-    pub fn best_n_within<F>(
-        &self,
-        query: &[A; K],
-        dist: A,
-        max_qty: usize,
-        distance_fn: &F,
-    ) -> impl Iterator<Item = T>
-    where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::zero(); K];
-        let mut best_items: BinaryHeap<T> = BinaryHeap::new();
-
-        unsafe {
-            self.best_n_within_recurse(
-                query,
-                dist,
-                max_qty,
-                distance_fn,
-                self.root_index,
-                0,
-                &mut best_items,
-                &mut off,
-                A::zero(),
-            );
-        }
-
-        best_items.into_iter()
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    unsafe fn best_n_within_recurse<F>(
-        &self,
-        query: &[A; K],
-        radius: A,
-        max_qty: usize,
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        best_items: &mut BinaryHeap<T>,
-        off: &mut [A; K],
-        rd: A,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = self.stems.get_unchecked(curr_node_idx.az::<usize>());
-
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim] - node.split_val;
-
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
-                } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
-
-            self.best_n_within_recurse(
-                query,
-                radius,
-                max_qty,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                best_items,
-                off,
-                rd,
-            );
-
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd + new_off * new_off - old_off * old_off;
-
-            if rd <= radius {
-                off[split_dim] = new_off;
-                self.best_n_within_recurse(
-                    query,
-                    radius,
-                    max_qty,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    best_items,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
-
-            Self::process_leaf_node(query, radius, max_qty, distance_fn, best_items, leaf_node);
-        }
-    }
-
-    unsafe fn process_leaf_node<F>(
-        query: &[A; K],
-        radius: A,
-        max_qty: usize,
-        distance_fn: &F,
-        best_items: &mut BinaryHeap<T>,
-        leaf_node: &$leafnode<A, T, K, B, IDX>,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        leaf_node
-            .content_points
-            .iter()
-            .take(leaf_node.size.az::<usize>())
-            .map(|entry| distance_fn(query, entry))
-            .enumerate()
-            .filter(|(_, distance)| *distance <= radius)
-            .for_each(|(idx, _)| {
-                Self::get_item_and_add_if_good(max_qty, best_items, leaf_node, idx)
-            });
-    }
-
-    unsafe fn get_item_and_add_if_good(
-        max_qty: usize,
-        best_items: &mut BinaryHeap<T>,
-        leaf_node: &$leafnode<A, T, K, B, IDX>,
-        idx: usize,
-    ) {
-        let item = *leaf_node.content_items.get_unchecked(idx.az::<usize>());
-        if best_items.len() < max_qty {
-            best_items.push(item);
-        } else {
-            let mut top = best_items.peek_mut().unwrap();
-            if item < *top {
-                *top = item;
-            }
-        }
-    }
-}}}
+```"
+            )
+        );
+    };
+}
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    generate_best_n_within!(
-        KdTree,
+    generate_float_best_n_within!(
         LeafNode,
         "let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
     tree.add(&[1.0, 2.0, 5.0], 100);
@@ -195,8 +64,7 @@ impl<
 where
     usize: Cast<IDX>,
 {
-    generate_best_n_within!(
-        ArchivedKdTree,
+    generate_float_best_n_within!(
         ArchivedLeafNode,
         "use std::fs::File;
     use memmap::MmapOptions;

--- a/src/float/query/best_n_within.rs
+++ b/src/float/query/best_n_within.rs
@@ -5,8 +5,6 @@ use az::{Az, Cast};
 use std::collections::BinaryHeap;
 use std::ops::Rem;
 
-
-
 macro_rules! generate_best_n_within {
         ($kdtree:ident, $leafnode:ident, $doctest_build_tree:tt) => {
         doc_comment! {
@@ -185,12 +183,17 @@ where
 }
 
 #[cfg(feature = "rkyv")]
-use crate::float::kdtree::{ArchivedKdTree,ArchivedLeafNode};
+use crate::float::kdtree::{ArchivedKdTree, ArchivedLeafNode};
 #[cfg(feature = "rkyv")]
-impl<A: Axis + rkyv::Archive<Archived = A>, T: Content + rkyv::Archive<Archived = T>, const K: usize, const B: usize, IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>>
-ArchivedKdTree<A, T, K, B, IDX>
-    where
-        usize: Cast<IDX>,
+impl<
+        A: Axis + rkyv::Archive<Archived = A>,
+        T: Content + rkyv::Archive<Archived = T>,
+        const K: usize,
+        const B: usize,
+        IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>,
+    > ArchivedKdTree<A, T, K, B, IDX>
+where
+    usize: Cast<IDX>,
 {
     generate_best_n_within!(
         ArchivedKdTree,

--- a/src/float/query/nearest_n.rs
+++ b/src/float/query/nearest_n.rs
@@ -1,15 +1,16 @@
 use crate::float::kdtree::{Axis, KdTree};
 use crate::float::neighbour::Neighbour;
-use crate::types::{Content, Index};
+use crate::types::{Content, Index, is_stem_index};
 use az::{Az, Cast};
 use std::collections::BinaryHeap;
 use std::ops::Rem;
 
+use crate::generate_nearest_n;
 
-macro_rules! genreate_nearest_n {
-    ($kdtree:ident, $doctest_build_tree:tt) => {
-    doc_comment! {
-    concat!("Finds the nearest `qty` elements to `query`, using the specified
+macro_rules! generate_float_nearest_n {
+    ($doctest_build_tree:tt) => {
+        generate_nearest_n!((
+            "Finds the nearest `qty` elements to `query`, using the specified
 distance metric function.
 # Examples
 
@@ -17,131 +18,26 @@ distance metric function.
     use kiddo::float::kdtree::KdTree;
     use kiddo::distance::squared_euclidean;
 
-    ",  $doctest_build_tree, "
+    ",
+            $doctest_build_tree,
+            "
 
     let nearest: Vec<_> = tree.nearest_n(&[1.0, 2.0, 5.1], 1, &squared_euclidean);
 
     assert_eq!(nearest.len(), 1);
     assert!((nearest[0].distance - 0.01f64).abs() < f64::EPSILON);
     assert_eq!(nearest[0].item, 100);
-```"),
-    #[inline]
-    pub fn nearest_n<F>(&self, query: &[A; K], qty: usize, distance_fn: &F) -> Vec<Neighbour<A, T>>
-    where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::zero(); K];
-        let mut result: BinaryHeap<Neighbour<A, T>> = BinaryHeap::with_capacity(qty);
-
-        unsafe {
-            self.nearest_n_recurse(
-                query,
-                distance_fn,
-                self.root_index,
-                0,
-                &mut result,
-                &mut off,
-                A::zero(),
-            )
-        }
-
-        result.into_sorted_vec()
-    }
-
-    unsafe fn nearest_n_recurse<F>(
-        &self,
-        query: &[A; K],
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        results: &mut BinaryHeap<Neighbour<A, T>>,
-        off: &mut [A; K],
-        rd: A,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if $kdtree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
-
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim] - node.split_val;
-
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
-                } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
-
-            self.nearest_n_recurse(
-                query,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                results,
-                off,
-                rd,
-            );
-
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd + new_off * new_off - old_off * old_off;
-            if Self::dist_belongs_in_heap(rd, results) {
-                off[split_dim] = new_off;
-                self.nearest_n_recurse(
-                    query,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    results,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
-
-            leaf_node
-                .content_points
-                .iter()
-                .take(leaf_node.size.az::<usize>())
-                .enumerate()
-                .for_each(|(idx, entry)| {
-                    let distance: A = distance_fn(query, entry);
-                    if Self::dist_belongs_in_heap(distance, results) {
-                        let item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
-                        let element = Neighbour { distance, item };
-                        if results.len() < results.capacity() {
-                            results.push(element)
-                        } else {
-                            let mut top = results.peek_mut().unwrap();
-                            if element.distance < top.distance {
-                                *top = element;
-                            }
-                        }
-                    }
-                });
-        }
-    }
-
-    fn dist_belongs_in_heap(dist: A, heap: &BinaryHeap<Neighbour<A, T>>) -> bool {
-        heap.is_empty() || dist < heap.peek().unwrap().distance || heap.len() < heap.capacity()
-    }
-}}}
-
+```"
+        ));
+    };
+}
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    genreate_nearest_n!(
-        KdTree,
+    generate_float_nearest_n!(
         "let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
     tree.add(&[1.0, 2.0, 5.0], 100);
     tree.add(&[2.0, 3.0, 6.0], 101);"
@@ -151,13 +47,17 @@ where
 #[cfg(feature = "rkyv")]
 use crate::float::kdtree::ArchivedKdTree;
 #[cfg(feature = "rkyv")]
-impl<A: Axis + rkyv::Archive<Archived = A>, T: Content + rkyv::Archive<Archived = T>, const K: usize, const B: usize, IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>>
-ArchivedKdTree<A, T, K, B, IDX>
-    where
-        usize: Cast<IDX>,
+impl<
+        A: Axis + rkyv::Archive<Archived = A>,
+        T: Content + rkyv::Archive<Archived = T>,
+        const K: usize,
+        const B: usize,
+        IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>,
+    > ArchivedKdTree<A, T, K, B, IDX>
+where
+    usize: Cast<IDX>,
 {
-    genreate_nearest_n!(
-        ArchivedKdTree,
+    generate_float_nearest_n!(
         "use std::fs::File;
     use memmap::MmapOptions;
 

--- a/src/float/query/nearest_n.rs
+++ b/src/float/query/nearest_n.rs
@@ -1,6 +1,6 @@
 use crate::float::kdtree::{Axis, KdTree};
 use crate::float::neighbour::Neighbour;
-use crate::types::{Content, Index, is_stem_index};
+use crate::types::{is_stem_index, Content, Index};
 use az::{Az, Cast};
 use std::collections::BinaryHeap;
 use std::ops::Rem;

--- a/src/float/query/nearest_one.rs
+++ b/src/float/query/nearest_one.rs
@@ -1,14 +1,15 @@
+use crate::float::kdtree::{Axis, KdTree, LeafNode};
+use crate::generate_nearest_one;
+use crate::types::{Content, Index, is_stem_index};
 use az::{Az, Cast};
 use std::ops::Rem;
 
-use crate::float::kdtree::{Axis, KdTree, LeafNode};
-use crate::types::{Content, Index};
-
-use crate::generate_nearest_one;
-
 macro_rules! generate_float_nearest_one {
-    ($kdtree:ident, $leafnode:ident, $doctest_build_tree:tt) => {
-    generate_nearest_one!($kdtree, $leafnode, ("Finds the nearest element to `query`, using the specified
+    ($leafnode:ident, $doctest_build_tree:tt) => {
+        generate_nearest_one!(
+            $leafnode,
+            (
+                "Finds the nearest element to `query`, using the specified
 distance metric function.
 
 Faster than querying for nearest_n(point, 1, ...) due
@@ -20,14 +21,19 @@ to not needing to allocate memory or maintain sorted results.
     use kiddo::float::kdtree::KdTree;
     use kiddo::distance::squared_euclidean;
 
-    ",  $doctest_build_tree, "
+    ",
+                $doctest_build_tree,
+                "
 
     let nearest = tree.nearest_one(&[1.0, 2.0, 5.1], &squared_euclidean);
 
     assert!((nearest.0 - 0.01f64).abs() < f64::EPSILON);
     assert_eq!(nearest.1, 100);
-```"));
-}}
+```"
+            )
+        );
+    };
+}
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
@@ -35,7 +41,6 @@ where
     usize: Cast<IDX>,
 {
     generate_float_nearest_one!(
-        KdTree,
         LeafNode,
         "let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
     tree.add(&[1.0, 2.0, 5.0], 100);
@@ -44,15 +49,19 @@ where
 }
 
 #[cfg(feature = "rkyv")]
-use crate::float::kdtree::{ArchivedKdTree,ArchivedLeafNode};
+use crate::float::kdtree::{ArchivedKdTree, ArchivedLeafNode};
 #[cfg(feature = "rkyv")]
-impl<A: Axis + rkyv::Archive<Archived = A>, T: Content + rkyv::Archive<Archived = T>, const K: usize, const B: usize, IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>>
-ArchivedKdTree<A, T, K, B, IDX>
-    where
-        usize: Cast<IDX>,
+impl<
+        A: Axis + rkyv::Archive<Archived = A>,
+        T: Content + rkyv::Archive<Archived = T>,
+        const K: usize,
+        const B: usize,
+        IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>,
+    > ArchivedKdTree<A, T, K, B, IDX>
+where
+    usize: Cast<IDX>,
 {
     generate_float_nearest_one!(
-        ArchivedKdTree,
         ArchivedLeafNode,
         "use std::fs::File;
     use memmap::MmapOptions;

--- a/src/float/query/nearest_one.rs
+++ b/src/float/query/nearest_one.rs
@@ -1,12 +1,14 @@
-use crate::float::kdtree::{Axis, KdTree, LeafNode};
-use crate::types::{Content, Index};
 use az::{Az, Cast};
 use std::ops::Rem;
 
-macro_rules! genreate_nearest_one {
+use crate::float::kdtree::{Axis, KdTree, LeafNode};
+use crate::types::{Content, Index};
+
+use crate::generate_nearest_one;
+
+macro_rules! generate_float_nearest_one {
     ($kdtree:ident, $leafnode:ident, $doctest_build_tree:tt) => {
-    doc_comment! {
-    concat!("Finds the nearest element to `query`, using the specified
+    generate_nearest_one!($kdtree, $leafnode, ("Finds the nearest element to `query`, using the specified
 distance metric function.
 
 Faster than querying for nearest_n(point, 1, ...) due
@@ -24,142 +26,15 @@ to not needing to allocate memory or maintain sorted results.
 
     assert!((nearest.0 - 0.01f64).abs() < f64::EPSILON);
     assert_eq!(nearest.1, 100);
-```"),
-    #[inline]
-    pub fn nearest_one<F>(&self, query: &[A; K], distance_fn: &F) -> (A, T)
-        where
-            F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::zero(); K];
-        unsafe {
-            self.nearest_one_recurse(
-                query,
-                distance_fn,
-                self.root_index,
-                0,
-                T::zero(),
-                A::max_value(),
-                &mut off,
-                A::zero(),
-            )
-        }
-    }
-
-    #[inline]
-    unsafe fn nearest_one_recurse<F>(
-        &self,
-        query: &[A; K],
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        mut best_item: T,
-        mut best_dist: A,
-        off: &mut [A; K],
-        rd: A,
-    ) -> (A, T)
-        where
-            F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = &self.stems.get_unchecked(curr_node_idx.az::<usize>());
-
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim] - node.split_val;
-
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
-                } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
-
-            let (dist, item) = self.nearest_one_recurse(
-                query,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                best_item,
-                best_dist,
-                off,
-                rd,
-            );
-
-            if dist < best_dist {
-                best_dist = dist;
-                best_item = item;
-            }
-
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd + new_off * new_off - old_off * old_off;
-            if rd <= best_dist {
-                off[split_dim] = new_off;
-                let (dist, item) = self.nearest_one_recurse(
-                    query,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    best_item,
-                    best_dist,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-
-                if dist < best_dist {
-                    best_dist = dist;
-                    best_item = item;
-                }
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
-
-            Self::search_content_for_best(
-                query,
-                distance_fn,
-                &mut best_item,
-                &mut best_dist,
-                leaf_node,
-            );
-        }
-
-        (best_dist, best_item)
-    }
-
-    fn search_content_for_best<F>(
-        query: &[A; K],
-        distance_fn: &F,
-        best_item: &mut T,
-        best_dist: &mut A,
-        leaf_node: &$leafnode<A, T, K, B, IDX>,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        leaf_node
-            .content_points
-            .iter()
-            .enumerate()
-            .take(leaf_node.size.az::<usize>())
-            .for_each(|(idx, entry)| {
-                let dist = distance_fn(query, entry);
-                if dist < *best_dist {
-                    *best_dist = dist;
-                    *best_item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
-                }
-            });
-    }
-}}}
+```"));
+}}
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    genreate_nearest_one!(
+    generate_float_nearest_one!(
         KdTree,
         LeafNode,
         "let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
@@ -176,7 +51,7 @@ ArchivedKdTree<A, T, K, B, IDX>
     where
         usize: Cast<IDX>,
 {
-    genreate_nearest_one!(
+    generate_float_nearest_one!(
         ArchivedKdTree,
         ArchivedLeafNode,
         "use std::fs::File;

--- a/src/float/query/nearest_one.rs
+++ b/src/float/query/nearest_one.rs
@@ -1,6 +1,6 @@
 use crate::float::kdtree::{Axis, KdTree, LeafNode};
 use crate::generate_nearest_one;
-use crate::types::{Content, Index, is_stem_index};
+use crate::types::{is_stem_index, Content, Index};
 use az::{Az, Cast};
 use std::ops::Rem;
 

--- a/src/float/query/within.rs
+++ b/src/float/query/within.rs
@@ -6,12 +6,14 @@ use crate::float::{
     kdtree::{Axis, KdTree},
     neighbour::Neighbour,
 };
-use crate::types::{Content, Index};
+use crate::types::{is_stem_index, Content, Index};
 
-macro_rules! generate_within {
-        ($kdtree:ident, $doctest_build_tree:tt) => {
-        doc_comment! {
-        concat!("Finds all elements within `dist` of `query`, using the specified
+use crate::generate_within;
+
+macro_rules! generate_float_within {
+    ($doctest_build_tree:tt) => {
+        generate_within!((
+            "Finds all elements within `dist` of `query`, using the specified
 distance metric function.
 
 Results are returned sorted nearest-first
@@ -19,126 +21,26 @@ Results are returned sorted nearest-first
 # Examples
 
 ```rust
-use kiddo::float::kdtree::KdTree;
-use kiddo::distance::squared_euclidean;
-",  $doctest_build_tree, "
+    use kiddo::float::kdtree::KdTree;
+    use kiddo::distance::squared_euclidean;
+    ",
+            $doctest_build_tree,
+            "
 
-let within = tree.within(&[1.0, 2.0, 5.0], 10f64, &squared_euclidean);
+    let within = tree.within(&[1.0, 2.0, 5.0], 10f64, &squared_euclidean);
 
-assert_eq!(within.len(), 2);
-```"),
-    #[inline]
-    pub fn within<F>(&self, query: &[A; K], dist: A, distance_fn: &F) -> Vec<Neighbour<A, T>>
-    where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        let mut off = [A::zero(); K];
-        let mut matching_items: BinaryHeap<Neighbour<A, T>> = BinaryHeap::new();
-
-        unsafe {
-            self.within_recurse(
-                query,
-                dist,
-                distance_fn,
-                self.root_index,
-                0,
-                &mut matching_items,
-                &mut off,
-                A::zero(),
-            );
-        }
-
-        matching_items.into_sorted_vec()
-    }
-
-    unsafe fn within_recurse<F>(
-        &self,
-        query: &[A; K],
-        radius: A,
-        distance_fn: &F,
-        curr_node_idx: IDX,
-        split_dim: usize,
-        matching_items: &mut BinaryHeap<Neighbour<A, T>>,
-        off: &mut [A; K],
-        rd: A,
-    ) where
-        F: Fn(&[A; K], &[A; K]) -> A,
-    {
-        if KdTree::<A, T, K, B, IDX>::is_stem_index(curr_node_idx) {
-            let node = self.stems.get_unchecked(curr_node_idx.az::<usize>());
-
-            let mut rd = rd;
-            let old_off = off[split_dim];
-            let new_off = query[split_dim] - node.split_val;
-
-            let [closer_node_idx, further_node_idx] =
-                if *query.get_unchecked(split_dim) < node.split_val {
-                    [node.left, node.right]
-                } else {
-                    [node.right, node.left]
-                };
-            let next_split_dim = (split_dim + 1).rem(K);
-
-            self.within_recurse(
-                query,
-                radius,
-                distance_fn,
-                closer_node_idx,
-                next_split_dim,
-                matching_items,
-                off,
-                rd,
-            );
-
-            // TODO: switch from dist_fn to a dist trait that can apply to 1D as well as KD
-            //       so that updating rd is not hardcoded to sq euclidean
-            rd = rd + new_off * new_off - old_off * old_off;
-
-            if rd <= radius {
-                off[split_dim] = new_off;
-                self.within_recurse(
-                    query,
-                    radius,
-                    distance_fn,
-                    further_node_idx,
-                    next_split_dim,
-                    matching_items,
-                    off,
-                    rd,
-                );
-                off[split_dim] = old_off;
-            }
-        } else {
-            let leaf_node = self
-                .leaves
-                .get_unchecked((curr_node_idx - IDX::leaf_offset()).az::<usize>());
-
-            leaf_node
-                .content_points
-                .iter()
-                .enumerate()
-                .take(leaf_node.size.az::<usize>())
-                .for_each(|(idx, entry)| {
-                    let distance = distance_fn(query, entry);
-
-                    if distance < radius {
-                        matching_items.push(Neighbour {
-                            distance,
-                            item: *leaf_node.content_items.get_unchecked(idx.az::<usize>()),
-                        })
-                    }
-                });
-        }
-    }
-}}}
+    assert_eq!(within.len(), 2);
+```"
+        ));
+    };
+}
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    generate_within!(
-        KdTree,
+    generate_float_within!(
         "
 let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
 tree.add(&[1.0, 2.0, 5.0], 100);
@@ -159,8 +61,7 @@ impl<
 where
     usize: Cast<IDX>,
 {
-    generate_within!(
-        ArchivedKdTree,
+    generate_float_within!(
         "use std::fs::File;
 use memmap::MmapOptions;
 

--- a/src/float/query/within.rs
+++ b/src/float/query/within.rs
@@ -8,7 +8,6 @@ use crate::float::{
 };
 use crate::types::{Content, Index};
 
-
 macro_rules! generate_within {
         ($kdtree:ident, $doctest_build_tree:tt) => {
         doc_comment! {
@@ -148,12 +147,17 @@ tree.add(&[2.0, 3.0, 6.0], 101);"
 }
 
 #[cfg(feature = "rkyv")]
-use crate::float::kdtree::{ArchivedKdTree};
+use crate::float::kdtree::ArchivedKdTree;
 #[cfg(feature = "rkyv")]
-impl<A: Axis + rkyv::Archive<Archived = A>, T: Content + rkyv::Archive<Archived = T>, const K: usize, const B: usize, IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>>
-ArchivedKdTree<A, T, K, B, IDX>
-    where
-        usize: Cast<IDX>,
+impl<
+        A: Axis + rkyv::Archive<Archived = A>,
+        T: Content + rkyv::Archive<Archived = T>,
+        const K: usize,
+        const B: usize,
+        IDX: Index<T = IDX> + rkyv::Archive<Archived = IDX>,
+    > ArchivedKdTree<A, T, K, B, IDX>
+where
+    usize: Cast<IDX>,
 {
     generate_within!(
         ArchivedKdTree,

--- a/src/float/query/within_unsorted.rs
+++ b/src/float/query/within_unsorted.rs
@@ -3,8 +3,36 @@ use az::{Az, Cast};
 use std::ops::Rem;
 
 use crate::float::kdtree::{Axis, KdTree};
-use crate::types::{Content, Index};
+use crate::types::{is_stem_index, Content, Index};
 
+use crate::generate_within_unsorted;
+
+macro_rules! generate_float_within_unsorted {
+    ($doctest_build_tree:tt) => {
+        generate_within_unsorted!((
+            "Finds all elements within `dist` of `query`, using the specified
+distance metric function.
+
+Results are returned in arbitrary order. Faster than `within`.
+
+# Examples
+
+```rust
+use kiddo::float::kdtree::KdTree;
+use kiddo::distance::squared_euclidean;
+",
+            $doctest_build_tree,
+            "
+
+let within = tree.within_unsorted(&[1.0, 2.0, 5.0], 10f64, &squared_euclidean);
+
+assert_eq!(within.len(), 2);
+```"
+        ));
+    };
+}
+
+/*
 macro_rules! generate_within_unsorted {
     ($kdtree:ident, $doctest_build_tree:tt) => {
         doc_comment! {
@@ -135,14 +163,14 @@ assert_eq!(within.len(), 2);
         }
     };
 }
+ */
 
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {
-    generate_within_unsorted!(
-        KdTree,
+    generate_float_within_unsorted!(
         "
 let mut tree: KdTree<f64, u32, 3, 32, u32> = KdTree::new();
 tree.add(&[1.0, 2.0, 5.0], 100);
@@ -163,8 +191,7 @@ impl<
 where
     usize: Cast<IDX>,
 {
-    generate_within_unsorted!(
-        ArchivedKdTree,
+    generate_float_within_unsorted!(
         "use std::fs::File;
 use memmap::MmapOptions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@ mod mirror_select_nth_unstable_by;
 pub mod test_utils;
 pub mod types;
 
+pub mod common;
+
 /// A floating-point k-d tree with default parameters.
 ///
 /// `A` is the floating point type (`f32` or `f64`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,8 @@ mod mirror_select_nth_unstable_by;
 pub mod test_utils;
 pub mod types;
 
-pub mod common;
+#[doc(hidden)]
+pub(crate) mod common;
 
 /// A floating-point k-d tree with default parameters.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -92,3 +92,7 @@ impl Index for u16 {
         (u16::MAX - u16::MAX.overflowing_shr(1).0) as usize * bucket_size
     }
 }
+
+pub(crate) fn is_stem_index<IDX: Index<T = IDX>>(x: IDX) -> bool {
+    x < <IDX as Index>::leaf_offset()
+}


### PR DESCRIPTION
Use for both `float::kdtree::KdTree` and `float::kdtree::ArchivedKdTree`.

Not implemented yet for `fixed::KdTree::ArchivedKDTree` due to `Fixed` types not being serializable with `rkyv` without being transmuted to a `u16` / `u32` / etc