### PR TITLE
feat!: `ImmutableKdTree` now works on stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,10 +130,10 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
-          version: "^0.5"
+          version: "^0.6"
 
       - name: Cargo check all targets and features
-        run: cargo hack check --workspace --each-feature --all-targets --exclude-features immutable,simd
+        run: cargo hack check --workspace --each-feature --all-targets --exclude-features global_allocate,simd
 
   check-unstable:
     name: Cargo Check (Nightly)
@@ -163,7 +163,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
-          version: "^0.5"
+          version: "^0.6"
 
       - name: Cargo check all targets and features
         run: cargo hack check --workspace --each-feature --all-targets
@@ -225,5 +225,5 @@ jobs:
           RUSTFLAGS: '-C target-cpu=native'
         run: |
           cargo run --example build-float-doctest-tree --features="serialize_rkyv"
-          cargo run --example build-immutable-doctest-tree --features="immutable serialize_rkyv"
+          cargo run --example build-immutable-doctest-tree --features="serialize_rkyv"
           cargo test --workspace --all-features --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ harness = false
 [[bench]]
 name = "nearest_one_immutable"
 harness = false
-required-features = ["immutable"]
 
 [[bench]]
 name = "nearest_n"
@@ -141,17 +140,16 @@ required-features = ["serialize_rkyv"]
 [[example]]
 name = "immutable-large"
 path = "examples/immutable-large.rs"
-required-features = ["immutable"]
 
 [[example]]
 name = "immutable-rkyv-serialize"
 path = "examples/immutable-rkyv-serialize.rs"
-required-features = ["immutable", "serialize_rkyv"]
+required-features = ["serialize_rkyv"]
 
 [[example]]
 name = "immutable-rkyv-deserialize"
 path = "examples/immutable-rkyv-deserialize.rs"
-required-features = ["immutable", "serialize_rkyv"]
+required-features = ["serialize_rkyv"]
 
 [[example]]
 name = "check-select-nth-unstable"
@@ -168,7 +166,7 @@ path = "examples/avx2-check.rs"
 [[example]]
 name = "build-immutable-doctest-tree"
 path = "examples/build-immutable-doctest-tree.rs"
-required-features = ["immutable", "serialize_rkyv"]
+required-features = ["serialize_rkyv"]
 
 [[example]]
 name = "build-float-doctest-tree"

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ See the [examples documentation](https://github.com/sdd/kiddo/tree/master/exampl
 
 ## Optional Features
 
-The Kiddo crate exposes the following features:
-* **serialize** - serialization / deserialization via [`Serde`](https://docs.rs/serde/latest/serde/)
-* **serialize_rkyv** - zero-copy serialization / deserialization via [`Rkyv`](https://docs.rs/rkyv/latest/rkyv/)
-* **immutable** - to use [`ImmutableKdTree`](`immutable::float::kdtree::ImmutableKdTree`)
-* **simd** - enables some hand written SIMD intrinsic code within [`ImmutableKdTree`](`immutable::float::kdtree::ImmutableKdTree`) that may improve performance (currently only on nearest_one with `f64`)
+The Kiddo crate exposes the following features. Any labelled as **(NIGHTLY)** are not available on `stable` Rust as they require some unstable features. You'll need to build with `nightly` in order to user them.
+* `serialize` - serialization / deserialization via [`Serde`](https://docs.rs/serde/latest/serde/)
+* `serialize_rkyv` - zero-copy serialization / deserialization via [`Rkyv`](https://docs.rs/rkyv/latest/rkyv/)
+* `global_allocate` **(NIGHTLY)** -  When enabled Kiddo will use the unstable allocator_api feature within [`ImmutableKdTree`](`immutable::float::kdtree::ImmutableKdTree`) to get a slight performance improvement when allocating space for leaves.
+* `simd` **(NIGHTLY)** - enables some hand-written SIMD intrinsic code within [`ImmutableKdTree`](`immutable::float::kdtree::ImmutableKdTree`) that may improve performance (currently only on the nearest_one method when using `f64`)
 
 ## v3.x
 

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -14,7 +14,6 @@ use flate2::Compression;
 use std::time::Instant;
 
 use kiddo::float::kdtree::KdTree;
-#[cfg(feature = "immutable")]
 use kiddo::immutable::float::kdtree::ImmutableKdTree;
 
 use serde::Deserialize;
@@ -102,43 +101,40 @@ fn main() -> Result<(), Box<dyn Error>> {
     let nearest_city = &cities[nearest_neighbour.item as usize];
     println!("\nNearest city to 52.5N, 1.9W: {:?}", nearest_city);
 
-    #[cfg(feature = "immutable")]
-    {
-        let city_points: Vec<_> = cities.iter().map(|city| city.as_xyz()).collect();
-        println!("Building an ImmutableKdTree...");
-        // Build an ImmutableKdTree
-        let start = Instant::now();
-        let kdtree: ImmutableKdTree<f32, u32, 3, 32> =
-            ImmutableKdTree::new_from_slice(&city_points);
-        println!(
-            "Built an ImmutableKdTree ({})",
-            ElapsedDuration::new(start.elapsed())
-        );
+    let city_points: Vec<_> = cities.iter().map(|city| city.as_xyz()).collect();
+    println!("Building an ImmutableKdTree...");
+    // Build an ImmutableKdTree
+    let start = Instant::now();
+    let kdtree: ImmutableKdTree<f32, u32, 3, 32> = ImmutableKdTree::new_from_slice(&city_points);
+    println!(
+        "Built an ImmutableKdTree ({})",
+        ElapsedDuration::new(start.elapsed())
+    );
 
-        let start = Instant::now();
-        let file = File::create("./examples/geonames-immutable-tree.bincode.gz")?;
-        let encoder = GzEncoder::new(file, Compression::default());
-        bincode::serialize_into(encoder, &kdtree)?;
-        println!(
-            "Serialized kd-tree to gzipped bincode file ({})",
-            ElapsedDuration::new(start.elapsed())
-        );
+    let start = Instant::now();
+    let file = File::create("./examples/geonames-immutable-tree.bincode.gz")?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    bincode::serialize_into(encoder, &kdtree)?;
+    println!(
+        "Serialized kd-tree to gzipped bincode file ({})",
+        ElapsedDuration::new(start.elapsed())
+    );
 
-        let start = Instant::now();
-        let file = File::open("./examples/geonames-immutable-tree.bincode.gz")?;
-        let decompressor = GzDecoder::new(file);
-        let deserialized_tree: ImmutableKdTree<f32, u32, 3, 32> =
-            bincode::deserialize_from(decompressor)?;
-        println!(
-            "Deserialized gzipped bincode file back into a kd-tree ({})",
-            ElapsedDuration::new(start.elapsed())
-        );
+    let start = Instant::now();
+    let file = File::open("./examples/geonames-immutable-tree.bincode.gz")?;
+    let decompressor = GzDecoder::new(file);
+    let deserialized_tree: ImmutableKdTree<f32, u32, 3, 32> =
+        bincode::deserialize_from(decompressor)?;
+    println!(
+        "Deserialized gzipped bincode file back into a kd-tree ({})",
+        ElapsedDuration::new(start.elapsed())
+    );
 
-        // Test that the deserialization worked
-        let query = degrees_lat_lng_to_unit_sphere(52.5f32, -1.9f32);
-        let nearest_neighbour_result = deserialized_tree.nearest_one::<SquaredEuclidean>(&query);
-        let nearest = &cities[nearest_neighbour_result.item as usize];
-        println!("\nNearest city to 52.5N, 1.9W: {:?}", nearest);
-    }
+    // Test that the deserialization worked
+    let query = degrees_lat_lng_to_unit_sphere(52.5f32, -1.9f32);
+    let nearest_neighbour_result = deserialized_tree.nearest_one::<SquaredEuclidean>(&query);
+    let nearest = &cities[nearest_neighbour_result.item as usize];
+    println!("\nNearest city to 52.5N, 1.9W: {:?}", nearest);
+
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(feature = "simd", feature(stdsimd))]
 #![cfg_attr(feature = "simd", feature(slice_as_chunks))]
-#![cfg_attr(feature = "immutable", feature(allocator_api))]
-#![cfg_attr(feature = "immutable", feature(int_roundings))]
+#![cfg_attr(feature = "global_allocate", feature(allocator_api))]
 #![warn(rustdoc::missing_crate_level_docs)]
 #![deny(rustdoc::invalid_codeblock_attributes)]
 #![warn(missing_docs)]
@@ -91,8 +90,6 @@ mod custom_serde;
 pub mod distance_metric;
 pub mod fixed;
 pub mod float;
-#[cfg(feature = "immutable")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "immutable")))]
 pub mod immutable;
 mod mirror_select_nth_unstable_by;
 pub mod nearest_neighbour;
@@ -120,7 +117,6 @@ pub type KdTree<A, const K: usize> = float::kdtree::KdTree<A, u64, K, 32, u32>;
 ///
 /// To manually specify more advanced parameters, use [`ImmutableKdTree`](`immutable::float::kdtree::ImmutableKdTree`) directly.
 /// To store positions using integer or fixed-point types, use [`fixed::kdtree::KdTree`].
-#[cfg(feature = "immutable")]
 pub type ImmutableKdTree<A, const K: usize> =
     immutable::float::kdtree::ImmutableKdTree<A, u64, K, 32>;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -10,9 +10,7 @@ use std::hint::black_box;
 
 use crate::fixed::kdtree::{Axis as AxisFixed, KdTree as FixedKdTree};
 use crate::float::kdtree::{Axis, KdTree};
-#[cfg(feature = "immutable")]
 use crate::float_leaf_simd::leaf_node::BestFromDists;
-#[cfg(feature = "immutable")]
 use crate::immutable::float::kdtree::ImmutableKdTree;
 use crate::types::{Content, Index};
 
@@ -132,7 +130,6 @@ where
     kdtree
 }
 
-#[cfg(feature = "immutable")]
 pub fn build_populated_tree_immutable_float<A: Axis, T: Content, const K: usize, const B: usize>(
     size: usize,
 ) -> ImmutableKdTree<A, T, K, B>
@@ -313,7 +310,6 @@ where
     )
 }
 
-#[cfg(feature = "immutable")]
 pub fn build_populated_tree_and_query_points_immutable_float<
     A: Axis,
     T: Content,
@@ -386,7 +382,6 @@ where
     )
 }
 
-#[cfg(feature = "immutable")]
 #[inline]
 pub fn process_queries_immutable_float<
     A: Axis + 'static,


### PR DESCRIPTION
* `immutable` crate feature removed - `ImmutableKdTree` now works with stable rust
* `global_allocate` crate feature added. When enabled, uses the unstable rust feature `allocator_api` so that `ImmutableKdTree` can get a small performance improvement when allocating memory

BREAKING CHANGE: the `immutable` crate feature now no longer exists.