### PR TITLE
fix: re-enable support for wasm targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ rayon = "1"
 fixed = { version = "1", features = ["num-traits"] }
 az = "1"
 doc-comment = "0.3"
-generator = "0.7"
 elapsed = "0.1"
 divrem = "1"
 ordered-float = "4"
@@ -57,6 +56,9 @@ rand_distr = "0.4"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
 codspeed-criterion-compat = "2.3.3"
+
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+generator = "0.7"
 
 [dependencies.serde]
 version = "1"

--- a/src/fixed/query/mod.rs
+++ b/src/fixed/query/mod.rs
@@ -3,4 +3,6 @@ pub mod nearest_n;
 pub mod nearest_one;
 pub mod within;
 pub mod within_unsorted;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod within_unsorted_iter;

--- a/src/fixed/query/within_unsorted_iter.rs
+++ b/src/fixed/query/within_unsorted_iter.rs
@@ -19,6 +19,8 @@ where
         (r#"Finds all elements within `dist` of `query`, using the specified
 distance metric function.
 
+Only available on x86_64 and aarch64 target architectures (this is due to a dependency
+on the generator crate).
 Returns an Iterator. Results are returned in arbitrary order. Faster than `within`.
 
 # Examples

--- a/src/float/query/mod.rs
+++ b/src/float/query/mod.rs
@@ -4,4 +4,6 @@ pub mod nearest_n_within;
 pub mod nearest_one;
 pub mod within;
 pub mod within_unsorted;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod within_unsorted_iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ pub mod nearest_neighbour;
 #[doc(hidden)]
 pub mod test_utils;
 pub mod types;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod within_unsorted_iter;
 
 #[doc(hidden)]


### PR DESCRIPTION
* The implementation of within_unsorted_iter on v3.0.0 made use of the generator crate, which only supports x86_64 and aarch64. The within_unsorted_iter methods have been made conditional, only being compiled on x86_64 or aarch64, so that the rest of the library works on other target architectures.