### PR TITLE
Iterate over trees

### DIFF
--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -9,8 +9,6 @@ use fixed::traits::Fixed;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
 
-#[cfg(feature = "serialize")]
-use crate::custom_serde::*;
 use crate::iter::TreeIter;
 use crate::{
     iter::IterableTreeData,
@@ -265,14 +263,19 @@ where
     ///
 
     /// ```
+    /// use fixed::FixedU16;
+    /// use fixed::types::extra::U0;
     /// use kiddo::fixed::kdtree::KdTree;
     ///
-    /// let point = [1u16, 2, 3];
-    /// let tree: KdTree<f16, u32, 3, 32> = KdTree::new();
-    /// tree.add(point, 10);
+    /// type Fxd = FixedU16<U0>;
     ///
-    /// let mut pairs: Vec<_> = tree.iter().collect()
-    /// assert_eq!(pairs.pop(), (10, point));
+    /// let point = [Fxd::from_num(1), Fxd::from_num(2), Fxd::from_num(3)];
+    /// let mut tree: KdTree<Fxd, u32, 3, 32, u32> = KdTree::new();
+    ///
+    /// tree.add(&point, 10);
+    ///
+    /// let mut pairs: Vec<_> = tree.iter().collect();
+    /// assert_eq!(pairs.pop().unwrap(), (10, point));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
         TreeIter::new(self, B)
@@ -494,7 +497,6 @@ mod tests {
 
     #[test]
     fn can_iterate() {
-        let pts = vec![[1, 2], [3, 4], [5, 6]];
         let mut tree: KdTree<Fxd, u32, 2, 2, u32> = KdTree::new();
 
         let content_to_add: Vec<(u32, [Fxd; 2])> = vec![

--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -275,7 +275,7 @@ where
     /// assert_eq!(pairs.pop(), (10, point));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
-        TreeIter::new(self)
+        TreeIter::new(self, B)
     }
 }
 

--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -6,8 +6,8 @@
 use az::{Az, Cast};
 use divrem::DivCeil;
 use fixed::traits::Fixed;
+use std::cmp::PartialEq;
 use std::fmt::Debug;
-use std::{cmp::PartialEq, collections::VecDeque};
 
 #[cfg(feature = "serialize")]
 use crate::custom_serde::*;
@@ -282,17 +282,17 @@ where
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     IterableTreeData<A, T, K> for KdTree<A, T, K, B, IDX>
 {
-    fn get_leaf_data(&self, idx: usize) -> Option<VecDeque<(T, [A; K])>> {
+    fn get_leaf_data(&self, idx: usize, out: &mut Vec<(T, [A; K])>) -> Option<usize> {
         let leaf = self.leaves.get(idx)?;
         let max = leaf.size.cast();
-        Some(
+        out.extend(
             leaf.content_items
                 .iter()
                 .cloned()
                 .zip(leaf.content_points.iter().cloned())
-                .take(max)
-                .collect(),
-        )
+                .take(max),
+        );
+        Some(max)
     }
 }
 

--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -298,6 +298,8 @@ impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use fixed::types::extra::U14;
     use fixed::FixedU16;
 
@@ -488,5 +490,26 @@ mod tests {
 
         let deserialized: KdTree<Fxd, u32, 4, 32, u32> = serde_json::from_str(&serialized).unwrap();
         assert_eq!(tree, deserialized);
+    }
+
+    #[test]
+    fn can_iterate() {
+        let pts = vec![[1, 2], [3, 4], [5, 6]];
+        let mut tree: KdTree<Fxd, u32, 2, 2, u32> = KdTree::new();
+
+        let content_to_add: Vec<(u32, [Fxd; 2])> = vec![
+            (9, [Fxd::from_num(0.9), Fxd::from_num(0)]),
+            (4, [Fxd::from_num(0.4), Fxd::from_num(0.5)]),
+            (12, [Fxd::from_num(0.12), Fxd::from_num(0.3)]),
+        ];
+
+        let mut expected: HashMap<u32, _> = HashMap::default();
+        for (item, point) in content_to_add {
+            tree.add(&point, item);
+            expected.insert(item, point);
+        }
+
+        let actual: HashMap<u32, _> = tree.iter().collect();
+        assert_eq!(actual, expected);
     }
 }

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -295,6 +295,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::float::kdtree::KdTree;
     type AX = f64;
 
@@ -353,5 +355,23 @@ mod tests {
 
         let deserialized: KdTree<f32, u32, 4, 32, u32> = serde_json::from_str(&serialized).unwrap();
         assert_eq!(tree, deserialized);
+    }
+
+    #[test]
+    fn can_iterate() {
+        let mut t: KdTree<f64, i32, 3, 2, u16> = KdTree::new();
+        let expected: HashMap<_, _> = vec![
+            (10, [1.0, 2.0, 3.0]),
+            (12, [10.0, 2.0, 3.0]),
+            (15, [1.0, 20.0, 3.0]),
+        ]
+        .into_iter()
+        .collect();
+
+        for (k, v) in expected.iter() {
+            t.add(v, *k);
+        }
+        let actual: HashMap<_, _> = t.iter().collect();
+        assert_eq!(actual, expected);
     }
 }

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -4,8 +4,8 @@
 use az::{Az, Cast};
 use divrem::DivCeil;
 use num_traits::float::FloatCore;
+use std::cmp::PartialEq;
 use std::fmt::Debug;
-use std::{cmp::PartialEq};
 
 #[cfg(feature = "serialize")]
 use crate::custom_serde::*;
@@ -208,7 +208,7 @@ where
     /// assert_eq!(pairs.pop(), (10, point));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
-        TreeIter::new(self)
+        TreeIter::new(self, B)
     }
 }
 

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -7,8 +7,6 @@ use num_traits::float::FloatCore;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
 
-#[cfg(feature = "serialize")]
-use crate::custom_serde::*;
 use crate::{
     iter::{IterableTreeData, TreeIter},
     types::{Content, Index},
@@ -198,14 +196,17 @@ where
     ///
 
     /// ```
-    /// use kiddo::float::kdtree::KdTree;
+    /// use kiddo::KdTree;
     ///
-    /// let point = [1.0f64, 2.0f64, 3.0f64];
-    /// let tree: KdTree<f64, u32, 3, 32> = KdTree::new();
-    /// tree.add(point, 10);
+    /// let mut tree: KdTree<f64, 3> = KdTree::new();
+    /// tree.add(&[1.0f64, 2.0f64, 3.0f64], 10);
+    /// tree.add(&[11.0f64, 12.0f64, 13.0f64], 20);
+    /// tree.add(&[21.0f64, 22.0f64, 23.0f64], 30);
     ///
-    /// let mut pairs: Vec<_> = tree.iter().collect()
-    /// assert_eq!(pairs.pop(), (10, point));
+    /// let mut pairs: Vec<_> = tree.iter().collect();
+    /// assert_eq!(pairs.pop().unwrap(), (10, [1.0f64, 2.0f64, 3.0f64]));
+    /// assert_eq!(pairs.pop().unwrap(), (20, [11.0f64, 12.0f64, 13.0f64]));
+    /// assert_eq!(pairs.pop().unwrap(), (30, [21.0f64, 22.0f64, 23.0f64]));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
         TreeIter::new(self, B)
@@ -359,7 +360,7 @@ mod tests {
 
     #[test]
     fn can_iterate() {
-        let mut t: KdTree<f64, i32, 3, 2, u16> = KdTree::new();
+        let mut t: KdTree<f64, i32, 3, 32, u16> = KdTree::new();
         let expected: HashMap<_, _> = vec![
             (10, [1.0, 2.0, 3.0]),
             (12, [10.0, 2.0, 3.0]),

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -4,10 +4,15 @@
 use az::{Az, Cast};
 use divrem::DivCeil;
 use num_traits::float::FloatCore;
-use std::cmp::PartialEq;
 use std::fmt::Debug;
+use std::{cmp::PartialEq, collections::VecDeque};
 
-use crate::types::{Content, Index};
+#[cfg(feature = "serialize")]
+use crate::custom_serde::*;
+use crate::{
+    iter::{IterableTreeData, TreeIter},
+    types::{Content, Index},
+};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
@@ -187,6 +192,40 @@ where
         tree.leaves.push(LeafNode::new());
 
         tree
+    }
+
+    /// Iterate over all `(index, point)` tuples in arbitrary order.
+    ///
+
+    /// ```
+    /// use kiddo::float::kdtree::KdTree;
+    ///
+    /// let point = [1.0f64, 2.0f64, 3.0f64];
+    /// let tree: KdTree<f64, u32, 3, 32> = KdTree::new();
+    /// tree.add(point, 10);
+    ///
+    /// let mut pairs: Vec<_> = tree.iter().collect()
+    /// assert_eq!(pairs.pop(), (10, point));
+    /// ```
+    pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
+        TreeIter::new(self)
+    }
+}
+
+impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
+    IterableTreeData<A, T, K> for KdTree<A, T, K, B, IDX>
+{
+    fn get_leaf_data(&self, idx: usize) -> Option<VecDeque<(T, [A; K])>> {
+        let leaf = self.leaves.get(idx)?;
+        let max = leaf.size.cast();
+        Some(
+            leaf.content_items
+                .iter()
+                .cloned()
+                .zip(leaf.content_points.iter().cloned())
+                .take(max)
+                .collect(),
+        )
     }
 }
 

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -5,7 +5,7 @@ use az::{Az, Cast};
 use divrem::DivCeil;
 use num_traits::float::FloatCore;
 use std::fmt::Debug;
-use std::{cmp::PartialEq, collections::VecDeque};
+use std::{cmp::PartialEq};
 
 #[cfg(feature = "serialize")]
 use crate::custom_serde::*;
@@ -215,17 +215,17 @@ where
 impl<A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX>>
     IterableTreeData<A, T, K> for KdTree<A, T, K, B, IDX>
 {
-    fn get_leaf_data(&self, idx: usize) -> Option<VecDeque<(T, [A; K])>> {
+    fn get_leaf_data(&self, idx: usize, out: &mut Vec<(T, [A; K])>) -> Option<usize> {
         let leaf = self.leaves.get(idx)?;
         let max = leaf.size.cast();
-        Some(
+        out.extend(
             leaf.content_items
                 .iter()
                 .cloned()
                 .zip(leaf.content_points.iter().cloned())
-                .take(max)
-                .collect(),
-        )
+                .take(max),
+        );
+        Some(max)
     }
 }
 

--- a/src/immutable/float/kdtree.rs
+++ b/src/immutable/float/kdtree.rs
@@ -591,7 +591,7 @@ where
     /// assert_eq!(pairs.pop(), (0, [1.0, 2.0, 3.0]));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
-        TreeIter::new(self)
+        TreeIter::new(self, B)
     }
 }
 

--- a/src/immutable/float/kdtree.rs
+++ b/src/immutable/float/kdtree.rs
@@ -587,8 +587,8 @@ where
     /// let points: Vec<[f64; 3]> = vec!([1.0f64, 2.0f64, 3.0f64]);
     /// let tree: ImmutableKdTree<f64, u32, 3, 32> = ImmutableKdTree::new_from_slice(&points);
     ///
-    /// let mut pairs: Vec<_> = tree.iter().collect()
-    /// assert_eq!(pairs.pop(), (0, [1.0, 2.0, 3.0]));
+    /// let mut pairs: Vec<_> = tree.iter().collect();
+    /// assert_eq!(pairs.pop().unwrap(), (0, [1.0, 2.0, 3.0]));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (T, [A; K])> + '_ {
         TreeIter::new(self, B)

--- a/src/immutable/float/kdtree.rs
+++ b/src/immutable/float/kdtree.rs
@@ -8,7 +8,6 @@
 use az::{Az, Cast};
 use ordered_float::OrderedFloat;
 use std::cmp::PartialEq;
-use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::ops::Rem;
 #[cfg(feature = "tracing")]
@@ -90,18 +89,17 @@ where
 impl<A: Axis, T: Content, const K: usize, const B: usize> IterableTreeData<A, T, K>
     for ImmutableKdTree<A, T, K, B>
 {
-    fn get_leaf_data(&self, idx: usize) -> Option<VecDeque<(T, [A; K])>> {
+    fn get_leaf_data(&self, idx: usize, out: &mut Vec<(T, [A; K])>) -> Option<usize> {
         let leaf = self.leaves.get(idx)?;
         let max = leaf.size;
-        let mut pts = VecDeque::with_capacity(max);
         for (pt_idx, content) in leaf.content_items[..max].iter().cloned().enumerate() {
             let mut arr = [A::default(); K];
             for (elem_idx, elem) in arr.iter_mut().enumerate() {
                 *elem = leaf.content_points[pt_idx][elem_idx];
             }
-            pts.push_back((content, arr));
+            out.push((content, arr));
         }
-        Some(pts)
+        Some(max)
     }
 }
 

--- a/src/immutable/float/kdtree.rs
+++ b/src/immutable/float/kdtree.rs
@@ -95,7 +95,7 @@ impl<A: Axis, T: Content, const K: usize, const B: usize> IterableTreeData<A, T,
         for (pt_idx, content) in leaf.content_items[..max].iter().cloned().enumerate() {
             let mut arr = [A::default(); K];
             for (elem_idx, elem) in arr.iter_mut().enumerate() {
-                *elem = leaf.content_points[pt_idx][elem_idx];
+                *elem = leaf.content_points[elem_idx][pt_idx];
             }
             out.push((content, arr));
         }
@@ -1045,8 +1045,7 @@ mod tests {
     #[test]
     fn can_iterate() {
         let pts = vec![[1.0, 2.0, 3.0], [10.0, 2.0, 3.0], [1.0, 20.0, 3.0]];
-        let mut t: ImmutableKdTree<f64, usize, 3, 2> =
-            ImmutableKdTree::new_from_slice(pts.as_slice());
+        let t: ImmutableKdTree<f64, usize, 3, 2> = ImmutableKdTree::new_from_slice(pts.as_slice());
 
         let expected = pts.iter().cloned().enumerate().collect();
         let actual: HashMap<_, _> = t.iter().collect();

--- a/src/immutable/float/kdtree.rs
+++ b/src/immutable/float/kdtree.rs
@@ -635,7 +635,7 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use std::panic;
+    use std::{collections::HashMap, panic};
 
     use crate::immutable::float::kdtree::ImmutableKdTree;
     use ordered_float::OrderedFloat;
@@ -1042,5 +1042,16 @@ mod tests {
             ImmutableKdTree::new_from_slice(&content_to_add);
 
         println!("Tree Stats: {:?}", tree.generate_stats())
+    }
+
+    #[test]
+    fn can_iterate() {
+        let pts = vec![[1.0, 2.0, 3.0], [10.0, 2.0, 3.0], [1.0, 20.0, 3.0]];
+        let mut t: ImmutableKdTree<f64, usize, 3, 2> =
+            ImmutableKdTree::new_from_slice(pts.as_slice());
+
+        let expected = pts.iter().cloned().enumerate().collect();
+        let actual: HashMap<_, _> = t.iter().collect();
+        assert_eq!(actual, expected);
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,19 +1,21 @@
 use std::collections::VecDeque;
 
-use crate::fixed::kdtree as fixed;
-use crate::float::kdtree as float;
-use crate::immutable::float::kdtree as immut;
-use crate::types::{Content, Index};
+use crate::types::Content;
 
-pub(crate) type LeafData<A: Copy + Default, T: Content, const K: usize> = VecDeque<(T, [A; K])>;
+pub(crate) type LeafData<A, T, const K: usize> = VecDeque<(T, [A; K])>;
 
 pub(crate) trait IterableTreeData<A: Copy + Default, T: Content, const K: usize> {
     fn get_leaf_data(&self, idx: usize) -> Option<LeafData<A, T, K>>;
 }
 
 #[derive(Debug)]
-pub struct TreeIter<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T, K>>
-{
+pub(crate) struct TreeIter<
+    'a,
+    A: Copy + Default,
+    T: Content,
+    const K: usize,
+    X: IterableTreeData<A, T, K>,
+> {
     tree: &'a X,
     leaf_idx: usize,
     leaf_data: Option<LeafData<A, T, K>>,
@@ -23,7 +25,6 @@ impl<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T
     TreeIter<'a, A, T, K, X>
 {
     pub(crate) fn new(tree: &'a X) -> Self {
-        let leaf_data = tree.get_leaf_data(0);
         Self {
             tree,
             leaf_idx: 0,
@@ -38,13 +39,10 @@ impl<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T
     type Item = (T, [A; K]);
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let mut data = self.leaf_data?;
-            if data.is_empty() {
-                self.leaf_data = self.tree.get_leaf_data(self.leaf_idx);
-                self.leaf_idx += 1;
-            }
-            return data.pop_front();
+        while self.leaf_data.as_ref()?.is_empty() {
+            self.leaf_data = self.tree.get_leaf_data(self.leaf_idx);
+            self.leaf_idx += 1;
         }
+        self.leaf_data.as_mut()?.pop_front()
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,50 @@
+use std::collections::VecDeque;
+
+use crate::fixed::kdtree as fixed;
+use crate::float::kdtree as float;
+use crate::immutable::float::kdtree as immut;
+use crate::types::{Content, Index};
+
+pub(crate) type LeafData<A: Copy + Default, T: Content, const K: usize> = VecDeque<(T, [A; K])>;
+
+pub(crate) trait IterableTreeData<A: Copy + Default, T: Content, const K: usize> {
+    fn get_leaf_data(&self, idx: usize) -> Option<LeafData<A, T, K>>;
+}
+
+#[derive(Debug)]
+pub struct TreeIter<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T, K>>
+{
+    tree: &'a X,
+    leaf_idx: usize,
+    leaf_data: Option<LeafData<A, T, K>>,
+}
+
+impl<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T, K>>
+    TreeIter<'a, A, T, K, X>
+{
+    pub(crate) fn new(tree: &'a X) -> Self {
+        let leaf_data = tree.get_leaf_data(0);
+        Self {
+            tree,
+            leaf_idx: 0,
+            leaf_data: Some(LeafData::default()),
+        }
+    }
+}
+
+impl<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T, K>> Iterator
+    for TreeIter<'a, A, T, K, X>
+{
+    type Item = (T, [A; K]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut data = self.leaf_data?;
+            if data.is_empty() {
+                self.leaf_data = self.tree.get_leaf_data(self.leaf_idx);
+                self.leaf_idx += 1;
+            }
+            return data.pop_front();
+        }
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -20,11 +20,11 @@ pub(crate) struct TreeIter<
 impl<'a, A: Copy + Default, T: Content, const K: usize, X: IterableTreeData<A, T, K>>
     TreeIter<'a, A, T, K, X>
 {
-    pub(crate) fn new(tree: &'a X) -> Self {
+    pub(crate) fn new(tree: &'a X, bucket_size: usize) -> Self {
         Self {
             tree,
             leaf_idx: 0,
-            leaf_data: Default::default(),
+            leaf_data: Vec::with_capacity(bucket_size),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub mod nearest_neighbour;
 pub mod test_utils;
 pub mod types;
 
-pub mod iter;
+mod iter;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod within_unsorted_iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ pub mod nearest_neighbour;
 pub mod test_utils;
 pub mod types;
 
+pub mod iter;
+
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod within_unsorted_iter;
 


### PR DESCRIPTION
(forked from @clbarnes's PR so I can fix some CI failures)

Resolves https://github.com/sdd/kiddo/issues/134.

Allows iteration, in arbitrary order, over points and indices in trees.