### PR TITLE
Make rand and rayon optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: LoliGothick/clippy-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          options: --features=serialize,serialize_rkyv --no-deps
+          options: --features=serialize,serialize_rkyv,test_utils --no-deps
           name: Clippy (stable)
 
       - name: Check Rustdoc Links
@@ -209,7 +209,7 @@ jobs:
         run: |
           cargo run --example build-float-doctest-tree --features="serialize_rkyv"
           cargo run --example build-immutable-doctest-tree --features="serialize_rkyv"
-          cargo test --workspace --features=serialize,serialize_rkyv
+          cargo test --workspace --features=serialize,serialize_rkyv,test_utils
 
   test-all-features:
     name: Run Tests (Nightly, all features enabled)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/sdd/kiddo"
 documentation = "https://docs.rs/kiddo"
 license = "MIT OR Apache-2.0"
 autobenches = false
+resolver = "2"
 
 [profile.release]
 debug = true
@@ -51,6 +52,9 @@ rand_distr = "0.4"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
 codspeed-criterion-compat = "2.3.3"
+# required to be able to run tests without specifying --features=test_utils
+# see https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
+kiddo = { path = ".", features = ["test_utils"] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 generator = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,30 +109,37 @@ all-features = true
 [[bench]]
 name = "add_points"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "nearest_one"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "nearest_one_immutable"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "nearest_n"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "within"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "within_unsorted"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "best_n"
 harness = false
+required-features = ["test_utils"]
 
 [[example]]
 name = "cities"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,12 @@ opt-level = 3
 [dependencies]
 log = "0.4"
 num-traits = "0.2"
-rand = "0.8" # delete at some point, only used in test bin
-rayon = "1"
 fixed = { version = "1", features = ["num-traits"] }
 az = "1"
 doc-comment = "0.3"
 elapsed = "0.1"
 divrem = "1"
 ordered-float = "4"
-rand_chacha = "0.3"
 itertools = "0.12"
 ubyte = "0.10.3"
 init_with = "1.1.0"
@@ -57,6 +54,18 @@ codspeed-criterion-compat = "2.3.3"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 generator = "0.7"
+
+[dependencies.rayon]
+version = "1"
+optional = true
+
+[dependencies.rand]
+version = "0.8"
+optional = true
+
+[dependencies.rand_chacha]
+version = "0.3"
+optional = true
 
 [dependencies.tracing]
 version = "0.1"
@@ -92,6 +101,7 @@ serialize_rkyv = ["rkyv"]
 simd = []
 tracing = ["dep:tracing", "tracing-subscriber"]
 default = ["tracing"]
+test_utils = ["rand", "rand_chacha", "rayon"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -151,6 +161,7 @@ required-features = ["serialize_rkyv"]
 [[example]]
 name = "immutable-large"
 path = "examples/immutable-large.rs"
+required-features = ["test_utils"]
 
 [[example]]
 name = "immutable-rkyv-serialize"
@@ -169,6 +180,7 @@ path = "examples/check-select-nth-unstable.rs"
 [[example]]
 name = "simd_leaf"
 path = "examples/simd_leaf.rs"
+required-features = ["test_utils"]
 
 [[example]]
 name = "avx2-check"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod immutable;
 mod mirror_select_nth_unstable_by;
 pub mod nearest_neighbour;
 #[doc(hidden)]
+#[cfg(feature = "test_utils")]
 pub mod test_utils;
 pub mod types;
 


### PR DESCRIPTION
(Update of https://github.com/sdd/kiddo/pull/136 to rebase on top of master and fix some issues with running tests - thanks @clbarnes!)

Both are only used in test utilities and examples, and both can interfere with WASM compilation.
Now both are behind a test_utils feature.