### PR TITLE
chore: release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kiddo Changelog
 
+## [4.1.1] - 2024-02-17
+
+### 🐛 Bug Fixes
+
+- Prevent overflow in capacity_with_bucket_size on non-64 bit architectures
+
 ## [4.1.0] - 2024-02-17
 
 ### Chore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "4.1.0"
+version = "4.1.1"
 edition = "2021"
 authors = ["Scott Donnelly <scott@donnel.ly>"]
 description = "A high-performance, flexible, ergonomic k-d tree library. Ideal for geo- and astro- nearest-neighbour and k-nearest-neighbor queries"


### PR DESCRIPTION
## 🤖 New release
* `kiddo`: 4.1.0 -> 4.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.1.1] - 2024-02-17

### 🐛 Bug Fixes

- Prevent overflow in capacity_with_bucket_size on non-64 bit architectures
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).