### PR TITLE
chore: release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Kiddo Changelog
 
+## [4.2.0] - 2024-02-18
+
+### ✨ Features
+
+- Add f16 support, example and docs to show usage with half crate
+
+### 🐛 Bug Fixes
+
+- Prevent assertion failure when stem optimisation needs a large shift
+
 ## [4.1.1] - 2024-02-17
 
 ### 🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "4.1.1"
+version = "4.2.0"
 edition = "2021"
 authors = ["Scott Donnelly <scott@donnel.ly>"]
 description = "A high-performance, flexible, ergonomic k-d tree library. Ideal for geo- and astro- nearest-neighbour and k-nearest-neighbor queries"


### PR DESCRIPTION
## 🤖 New release
* `kiddo`: 4.1.1 -> 4.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.2.0] - 2024-02-18

### ✨ Features

- Add f16 support, example and docs to show usage with half crate

### 🐛 Bug Fixes

- Prevent assertion failure when stem optimisation needs a large shift
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).