### PR TITLE
upgrade generator to 0.8.1 (required some changes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ codspeed-criterion-compat = "2"
 kiddo = { path = ".", features = ["test_utils"] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-generator = "0.7"
+generator = "0.8.1"
 
 [dependencies.rayon]
 version = "1"

--- a/src/common/generate_within_unsorted_iter.rs
+++ b/src/common/generate_within_unsorted_iter.rs
@@ -35,16 +35,16 @@ macro_rules! generate_within_unsorted_iter {
             }
 
             #[allow(clippy::too_many_arguments)]
-            unsafe fn within_unsorted_iter_recurse<D>(
+            unsafe fn within_unsorted_iter_recurse<'scope, D>(
                 &'a self,
                 query: &[A; K],
                 radius: A,
                 curr_node_idx: IDX,
                 split_dim: usize,
-                mut gen_scope: Scope<'a, (), NearestNeighbour<A, T>>,
+                mut gen_scope: Scope<'scope, 'a, (), NearestNeighbour<A, T>>,
                 off: &mut [A; K],
                 rd: A,
-            ) -> Scope<(), NearestNeighbour<A, T>>
+            ) -> Scope<'scope, 'a, (), NearestNeighbour<A, T>>
             where
                 D: DistanceMetric<A, K>,
             {
@@ -102,7 +102,7 @@ macro_rules! generate_within_unsorted_iter {
                             let distance = D::dist(query, entry);
 
                             if distance < radius {
-                                gen_scope.yield_(NearestNeighbour {
+                                gen_scope.yield_with(NearestNeighbour {
                                     distance,
                                     item: *leaf_node.content_items.get_unchecked(idx.az::<usize>()),
                                 });


### PR DESCRIPTION
Supersedes #157.

The main change was that `yield_` is now only available for `Scope<'scope, 'static, ...>`. Is replacement for `Scope<'scope, 'a, ...>` is `yield_unsafe`, but the safety requirements are hard to evaluate, not having written this code. So now we call `yield_with`, because we didn't need the return value anyway (which is "the current para", whatever that means) and it's not unsafe.

The resulting code has one fewer compiler fence, which may have a very slight perf bonus but I don't think you'll be able to measure it.