### PR TITLE
Added test to capture edge cases with unsorted count

### DIFF
--- a/src/float/query/nearest_n_within.rs
+++ b/src/float/query/nearest_n_within.rs
@@ -231,6 +231,71 @@ mod tests {
     }
 
     #[test]
+    fn can_query_nearest_n_items_unsorted_max_qty() {
+        let mut tree: KdTree<AX, u32, 4, 4, u32> = KdTree::new();
+
+        let content_to_add: [([AX; 4], u32); 16] = [
+            ([0.9f32, 0.0f32, 0.9f32, 0.0f32], 9),
+            ([0.4f32, 0.5f32, 0.4f32, 0.5f32], 4),
+            ([0.12f32, 0.3f32, 0.12f32, 0.3f32], 12),
+            ([0.7f32, 0.2f32, 0.7f32, 0.2f32], 7),
+            ([0.13f32, 0.4f32, 0.13f32, 0.4f32], 13),
+            ([0.6f32, 0.3f32, 0.6f32, 0.3f32], 6),
+            ([0.2f32, 0.7f32, 0.2f32, 0.7f32], 2),
+            ([0.14f32, 0.5f32, 0.14f32, 0.5f32], 14),
+            ([0.3f32, 0.6f32, 0.3f32, 0.6f32], 3),
+            ([0.10f32, 0.1f32, 0.10f32, 0.1f32], 10),
+            ([0.16f32, 0.7f32, 0.16f32, 0.7f32], 16),
+            ([0.1f32, 0.8f32, 0.1f32, 0.8f32], 1),
+            ([0.15f32, 0.6f32, 0.15f32, 0.6f32], 15),
+            ([0.5f32, 0.4f32, 0.5f32, 0.4f32], 5),
+            ([0.8f32, 0.1f32, 0.8f32, 0.1f32], 8),
+            ([0.11f32, 0.2f32, 0.11f32, 0.2f32], 11),
+        ];
+
+        for (point, item) in content_to_add {
+            tree.add(&point, item);
+        }
+
+        let query_point = [0.78f32, 0.55f32, 0.78f32, 0.55f32];
+
+        let radius = 100.0;
+        let max_qty = 1;
+
+        let result_unsorted: Vec<_> = tree
+            .nearest_n_within::<SquaredEuclidean>(&query_point, radius, max_qty, false)
+            .into_iter()
+            .map(|n| (n.distance, n.item))
+            .collect();
+
+        let result_sorted: Vec<_> = tree
+            .nearest_n_within::<SquaredEuclidean>(&query_point, radius, max_qty, true)
+            .into_iter()
+            .map(|n| (n.distance, n.item))
+            .collect();
+
+        assert_eq!(result_unsorted.len(), max_qty);
+        assert_eq!(result_sorted.len(), max_qty);
+
+        let max_qty = 0;
+
+        let result_unsorted: Vec<_> = tree
+            .nearest_n_within::<SquaredEuclidean>(&query_point, radius, max_qty, false)
+            .into_iter()
+            .map(|n| (n.distance, n.item))
+            .collect();
+
+        let result_sorted: Vec<_> = tree
+            .nearest_n_within::<SquaredEuclidean>(&query_point, radius, max_qty, true)
+            .into_iter()
+            .map(|n| (n.distance, n.item))
+            .collect();
+
+        assert_eq!(result_unsorted.len(), max_qty);
+        assert_eq!(result_sorted.len(), max_qty);
+    }
+
+    #[test]
     fn can_query_nearest_n_items_within_radius_unsorted_large_scale() {
         const TREE_SIZE: usize = 100_000;
         const NUM_QUERIES: usize = 100;


### PR DESCRIPTION
### Description

This PR introduces a new test to handle edge cases when querying for `nearest_n_within`. The test is designed to ensure that the `nearest_n_within` function behaves as expected, particularly with the `max_qty` and `sorted` parameters.

#### Key Changes:
- Added a new test function `can_query_nearest_n_items_unsorted_max_qty` in `src/float/query/nearest_n_within.rs`.
- The test covers scenarios with both non-zero and zero values for `max_qty`, verifying that the function returns the correct number of results when sorted or unsorted.

#### Confirmation of Fix:
This test confirms that the fix introduced in PR #175 for issue #168 works as intended. 

However, it also reveals that the function behaves differently when `max_qty` is set to 0, depending on whether the results are sorted or not. When `sorted` is `true`, the function handles `max_qty` = 0 correctly, but when `sorted` is `false`, it fails to return the expected empty result set.

This addition helps to ensure that edge cases are handled correctly and that the `nearest_n_within` function performs consistently under various conditions.
