### PR TITLE
chore: release v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Silence new lint error
 - Silence error regarding doc_cfg no longer working
 - Update codspeedhq/action action to v3
+- Update rust crate generator to 0.8.1
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Kiddo Changelog
 
+## [4.2.1] - 2024-08-17
+
+### Chore
+
+- Refactor trait bounds to silence new clippy lints
+- Silence new lint error
+- Silence error regarding doc_cfg no longer working
+- Update codspeedhq/action action to v3
+
+### 🐛 Bug Fixes
+
+- Nearest_n_within does not limit num of items when not sorted, Issue:https://github.com/sdd/kiddo/issues/168
+- Update rust crate itertools to 0.13
+
 ## [4.2.0] - 2024-02-18
 
 ### ✨ Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 authors = ["Scott Donnelly <scott@donnel.ly>"]
 description = "A high-performance, flexible, ergonomic k-d tree library. Ideal for geo- and astro- nearest-neighbour and k-nearest-neighbor queries"


### PR DESCRIPTION
## 🤖 New release
* `kiddo`: 4.2.0 -> 4.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.2.1] - 2024-08-17

### Chore

- Refactor trait bounds to silence new clippy lints
- Silence new lint error
- Silence error regarding doc_cfg no longer working
- Update codspeedhq/action action to v3

### 🐛 Bug Fixes

- Nearest_n_within does not limit num of items when not sorted, Issue:https://github.com/sdd/kiddo/issues/168
- Update rust crate itertools to 0.13
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).