### PR TITLE
chore: release v5.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 authors = ["Scott Donnelly <scott@donnel.ly>"]
 description = "A high-performance, flexible, ergonomic k-d tree library. Ideal for geo- and astro- nearest-neighbour and k-nearest-neighbor queries"


### PR DESCRIPTION
## 🤖 New release
* `kiddo`: 5.0.0 -> 5.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [5.0.1] - 2024-12-08

### Performance

- fix a performance regression on the immutable tree.

### Documentation

- ensure that the top-level documentation example shows v5 being imported.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).