### PR TITLE
WIP: Improve the flexibility of T type, KdTree.size, and provide nearest_one_point

### DIFF
--- a/src/common/generate_nearest_one.rs
+++ b/src/common/generate_nearest_one.rs
@@ -9,14 +9,23 @@ macro_rules! generate_nearest_one {
                 where
                     D: DistanceMetric<A, K>,
             {
-                let mut off = [A::zero(); K];
+                self.nearest_one_point::<D>(query).0
+            }
 
+            #[inline]
+            pub fn nearest_one_point<D>(&self, query: &[A; K]) -> (NearestNeighbour<A, T>, [A; K])
+                where
+                    D: DistanceMetric<A, K>,
+            {
+                let mut nearest_entry = [A::zero(); K];
+                let mut off = [A::zero(); K];
                 unsafe {
                     self.nearest_one_recurse::<D>(
                         query,
                         self.root_index,
                         0,
-                        NearestNeighbour { distance: A::max_value(), item: T::zero() },
+                        NearestNeighbour { distance: A::max_value(), item: T::default()},
+                        &mut nearest_entry,
                         &mut off,
                         A::zero(),
                     )
@@ -30,9 +39,10 @@ macro_rules! generate_nearest_one {
                 curr_node_idx: IDX,
                 split_dim: usize,
                 mut nearest: NearestNeighbour<A, T>,
+                nearest_entry: &mut [A; K],
                 off: &mut [A; K],
                 rd: A,
-            ) -> NearestNeighbour<A, T>
+            ) -> (NearestNeighbour<A, T>, [A; K])
                 where
                     D: DistanceMetric<A, K>,
             {
@@ -51,28 +61,31 @@ macro_rules! generate_nearest_one {
                         };
                     let next_split_dim = (split_dim + 1).rem(K);
 
-                    let nearest_neighbour = self.nearest_one_recurse::<D>(
+                    let (nearest_neighbour, nearest_neighbour_entry) = self.nearest_one_recurse::<D>(
                         query,
                         closer_node_idx,
                         next_split_dim,
                         nearest,
+                        nearest_entry,
                         off,
                         rd,
                     );
 
                     if nearest_neighbour < nearest {
                         nearest = nearest_neighbour;
+                        nearest_entry.copy_from_slice( &nearest_neighbour_entry );
                     }
 
                     rd = Axis::rd_update(rd, D::dist1(new_off, old_off));
 
                     if rd <= nearest.distance {
                         off[split_dim] = new_off;
-                        let result = self.nearest_one_recurse::<D>(
+                        let (result, result_entry) = self.nearest_one_recurse::<D>(
                             query,
                             further_node_idx,
                             next_split_dim,
                             nearest,
+                            nearest_entry,
                             off,
                             rd,
                         );
@@ -80,6 +93,7 @@ macro_rules! generate_nearest_one {
 
                         if result < nearest {
                             nearest = result;
+                            nearest_entry.copy_from_slice( &result_entry );
                         }
                     }
                 } else {
@@ -90,17 +104,19 @@ macro_rules! generate_nearest_one {
                     Self::search_content_for_nearest::<D>(
                         query,
                         &mut nearest,
+                        nearest_entry,
                         leaf_node,
                     );
                 }
 
-                nearest
+                (nearest, nearest_entry.clone())
             }
 
             #[inline]
             fn search_content_for_nearest<D>(
                 query: &[A; K],
                 nearest: &mut NearestNeighbour<A, T>,
+                nearest_entry: &mut [A; K],
                 leaf_node: &$leafnode<A, T, K, B, IDX>,
             ) where
                 D: DistanceMetric<A, K>,
@@ -115,6 +131,7 @@ macro_rules! generate_nearest_one {
                         if dist < nearest.distance {
                             nearest.distance = dist;
                             nearest.item = unsafe { *leaf_node.content_items.get_unchecked(idx) };
+                            nearest_entry.copy_from_slice( entry );
                         }
                     });
             }

--- a/src/fixed/construction.rs
+++ b/src/fixed/construction.rs
@@ -79,7 +79,7 @@ where
 
             leaf_node.size = leaf_node.size + IDX::one();
         }
-        self.size = self.size + T::one();
+        self.size += 1;
     }
 
     /// Removes an item from the tree.
@@ -141,7 +141,7 @@ where
                     leaf_node.content_items[p_index] =
                         leaf_node.content_items[leaf_node.size.az::<usize>() - 1];
 
-                    self.size -= T::one();
+                    self.size -= 1;
                     removed += 1;
                     leaf_node.size = leaf_node.size - IDX::one();
                 } else {

--- a/src/fixed/kdtree.rs
+++ b/src/fixed/kdtree.rs
@@ -61,7 +61,7 @@ pub struct KdTreeRK<
     pub(crate) leaves: Vec<LeafNodeRK<A, T, K, B, IDX>>,
     pub(crate) stems: Vec<StemNodeRK<A, K, IDX>>,
     pub(crate) root_index: IDX,
-    pub(crate) size: T,
+    pub(crate) size: usize,
 }
 
 /// Fixed point k-d tree
@@ -76,7 +76,7 @@ pub struct KdTree<A: Copy + Default, T: Copy + Default, const K: usize, const B:
     pub(crate) leaves: Vec<LeafNode<A, T, K, B, IDX>>,
     pub(crate) stems: Vec<StemNode<A, K, IDX>>,
     pub(crate) root_index: IDX,
-    pub(crate) size: T,
+    pub(crate) size: usize,
 }
 
 #[doc(hidden)]
@@ -163,7 +163,7 @@ where
     pub(crate) fn new() -> Self {
         Self {
             content_points: [[A::ZERO; K]; B],
-            content_items: [T::zero(); B],
+            content_items: [T::default(); B],
             size: IDX::zero(),
         }
     }
@@ -225,7 +225,7 @@ where
     pub fn with_capacity(capacity: usize) -> Self {
         assert!(capacity <= <IDX as Index>::capacity_with_bucket_size(B));
         let mut tree = Self {
-            size: T::zero(),
+            size: 0,
             stems: Vec::with_capacity(capacity.max(1).ilog2() as usize),
             leaves: Vec::with_capacity(DivCeil::div_ceil(capacity, B.az::<usize>())),
             root_index: <IDX as Index>::leaf_offset(),
@@ -255,7 +255,7 @@ where
     /// assert_eq!(tree.size(), 2);
     /// ```
     #[inline]
-    pub fn size(&self) -> T {
+    pub fn size(&self) -> usize {
         self.size
     }
 

--- a/src/fixed/query/best_n_within.rs
+++ b/src/fixed/query/best_n_within.rs
@@ -158,7 +158,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[Fxd; 4]> = (0..NUM_QUERIES)
             .map(|_| rand_data_fixed_u16_point::<U14, 4>())

--- a/src/fixed/query/nearest_n.rs
+++ b/src/fixed/query/nearest_n.rs
@@ -136,7 +136,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[Fxd; 4]> = (0..NUM_QUERIES)
             .map(|_| rand_data_fixed_u16_point::<U14, 4>())

--- a/src/fixed/query/nearest_one.rs
+++ b/src/fixed/query/nearest_one.rs
@@ -21,6 +21,8 @@ distance metric function.
 Faster than querying for nearest_n(point, 1, ...) due
 to not needing to allocate memory or maintain sorted results.
 
+The nearest_one_point version also returns the coordinates of the nearest point.
+
 # Examples
 
 ```rust
@@ -40,6 +42,12 @@ to not needing to allocate memory or maintain sorted results.
 
     assert_eq!(nearest.distance, Fxd::from_num(0));
     assert_eq!(nearest.item, 100);
+
+    let (nearest, nearest_point) = tree.nearest_one_point::<SquaredEuclidean>(&[Fxd::from_num(1), Fxd::from_num(2), Fxd::from_num(5)]);
+
+    assert_eq!(nearest.distance, Fxd::from_num(0));
+    assert_eq!(nearest.item, 100);
+    assert_eq!(nearest_point, [Fxd::from_num(1), Fxd::from_num(2), Fxd::from_num(5)]);
 ```"#)
     );
 }
@@ -128,7 +136,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[Fxd; 4]> = (0..NUM_QUERIES)
             .map(|_| rand_data_fixed_u16_point::<U14, 4>())

--- a/src/fixed/query/within.rs
+++ b/src/fixed/query/within.rs
@@ -136,7 +136,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[Fxd; 4]> = (0..NUM_QUERIES)
             .map(|_| rand_data_fixed_u16_point::<U14, 4>())

--- a/src/fixed/query/within_unsorted.rs
+++ b/src/fixed/query/within_unsorted.rs
@@ -137,7 +137,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[Fxd; 4]> = (0..NUM_QUERIES)
             .map(|_| rand_data_fixed_u16_point::<U14, 4>())

--- a/src/fixed/query/within_unsorted_iter.rs
+++ b/src/fixed/query/within_unsorted_iter.rs
@@ -141,7 +141,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[Fxd; 4]> = (0..NUM_QUERIES)
             .map(|_| rand_data_fixed_u16_point::<U14, 4>())

--- a/src/float/construction.rs
+++ b/src/float/construction.rs
@@ -74,7 +74,7 @@ where
 
             leaf_node.size = leaf_node.size + IDX::one();
         }
-        self.size = self.size + T::one();
+        self.size += 1;
     }
 
     /// Removes an item from the tree.
@@ -132,7 +132,7 @@ where
                     leaf_node.content_items[p_index] =
                         leaf_node.content_items[leaf_node.size.az::<usize>() - 1];
 
-                    self.size -= T::one();
+                    self.size -= 1;
                     removed += 1;
                     leaf_node.size = leaf_node.size - IDX::one();
                 } else {

--- a/src/float/kdtree.rs
+++ b/src/float/kdtree.rs
@@ -67,7 +67,7 @@ pub struct KdTree<A: Copy + Default, T: Copy + Default, const K: usize, const B:
     pub(crate) leaves: Vec<LeafNode<A, T, K, B, IDX>>,
     pub(crate) stems: Vec<StemNode<A, K, IDX>>,
     pub(crate) root_index: IDX,
-    pub(crate) size: T,
+    pub(crate) size: usize,
 }
 
 #[doc(hidden)]
@@ -125,7 +125,7 @@ where
     pub(crate) fn new() -> Self {
         Self {
             content_points: [[A::zero(); K]; B],
-            content_items: [T::zero(); B],
+            content_items: [T::default(); B],
             size: IDX::zero(),
         }
     }
@@ -187,7 +187,7 @@ where
     pub fn with_capacity(capacity: usize) -> Self {
         assert!(capacity <= <IDX as Index>::capacity_with_bucket_size(B));
         let mut tree = Self {
-            size: T::zero(),
+            size: 0,
             stems: Vec::with_capacity(capacity.max(1).ilog2() as usize),
             leaves: Vec::with_capacity(DivCeil::div_ceil(capacity, B.az::<usize>())),
             root_index: <IDX as Index>::leaf_offset(),
@@ -269,7 +269,7 @@ macro_rules! generate_common_methods {
         /// assert_eq!(tree.size(), 2);
         /// ```
         #[inline]
-        pub fn size(&self) -> T {
+        pub fn size(&self) -> usize {
             self.size
         }
     };

--- a/src/float/query/best_n_within.rs
+++ b/src/float/query/best_n_within.rs
@@ -170,7 +170,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as i32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[AX; 2]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[AX; 2]>())

--- a/src/float/query/nearest_n.rs
+++ b/src/float/query/nearest_n.rs
@@ -155,7 +155,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[f32; 4]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[f32; 4]>())

--- a/src/float/query/nearest_n_within.rs
+++ b/src/float/query/nearest_n_within.rs
@@ -296,7 +296,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[f32; 4]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[f32; 4]>())

--- a/src/float/query/nearest_one.rs
+++ b/src/float/query/nearest_one.rs
@@ -18,6 +18,8 @@ distance metric function.
 Faster than querying for nearest_n(point, 1, ...) due
 to not needing to allocate memory or maintain sorted results.
 
+The nearest_one_point version also returns the coordinates of the nearest point.
+
 # Examples
 
 ```rust
@@ -32,6 +34,12 @@ to not needing to allocate memory or maintain sorted results.
 
     assert!((nearest.distance - 0.01f64).abs() < f64::EPSILON);
     assert_eq!(nearest.item, 100);
+
+    let (nearest, nearest_point) = tree.nearest_one_point::<SquaredEuclidean>(&[1.0, 2.0, 5.1]);
+
+    assert!((nearest.distance - 0.01f64).abs() < f64::EPSILON);
+    assert_eq!(nearest.item, 100);
+    assert_eq!(nearest_point, [1.0, 2.0, 5.0]);
 ```"
             )
         );
@@ -152,7 +160,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[f32; 4]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[f32; 4]>())

--- a/src/float/query/within.rs
+++ b/src/float/query/within.rs
@@ -148,7 +148,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[f32; 4]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[f32; 4]>())

--- a/src/float/query/within_unsorted.rs
+++ b/src/float/query/within_unsorted.rs
@@ -155,7 +155,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[f32; 4]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[f32; 4]>())

--- a/src/float/query/within_unsorted_iter.rs
+++ b/src/float/query/within_unsorted_iter.rs
@@ -155,7 +155,7 @@ mod tests {
         content_to_add
             .iter()
             .for_each(|(point, content)| tree.add(point, *content));
-        assert_eq!(tree.size(), TREE_SIZE as u32);
+        assert_eq!(tree.size(), TREE_SIZE);
 
         let query_points: Vec<[f32; 4]> = (0..NUM_QUERIES)
             .map(|_| rand::random::<[f32; 4]>())

--- a/src/hybrid/construction.rs
+++ b/src/hybrid/construction.rs
@@ -232,7 +232,7 @@ where
                     leaf_node.content_items[p_index] =
                         leaf_node.content_items[leaf_node.size.az::<usize>() - 1];
 
-                    self.size -= T::one();
+                    self.size -= 1;
                     removed += 1;
                     leaf_node.size = leaf_node.size - IDX::one();
                 } else {

--- a/src/hybrid/kdtree.rs
+++ b/src/hybrid/kdtree.rs
@@ -156,7 +156,7 @@ where
     pub(crate) fn new() -> Self {
         Self {
             content_points: [[A::zero(); K]; B],
-            content_items: [T::zero(); B],
+            content_items: [T::default(); B],
             size: IDX::zero(),
         }
     }

--- a/src/hybrid/query/nearest_one.rs
+++ b/src/hybrid/query/nearest_one.rs
@@ -49,7 +49,7 @@ where
                 distance_fn,
                 StemIdx::Stem(IDX::one()),
                 0,
-                T::zero(),
+                T::default(),
                 A::max_value(),
                 &mut off,
                 A::zero(),

--- a/src/immutable/common/generate_immutable_approx_nearest_one.rs
+++ b/src/immutable/common/generate_immutable_approx_nearest_one.rs
@@ -20,7 +20,7 @@ macro_rules! generate_immutable_approx_nearest_one {
                 let mut curr_idx: usize = 1;
 
                 let mut dim: usize = 0;
-                let mut best_item = T::zero();
+                let mut best_item = T::default();
                 let mut best_dist = A::max_value();
                 let mut level: usize = 0;
                 let mut leaf_idx: usize = 0;

--- a/src/immutable/common/generate_immutable_nearest_one.rs
+++ b/src/immutable/common/generate_immutable_nearest_one.rs
@@ -12,7 +12,7 @@ macro_rules! generate_immutable_nearest_one {
                 let mut off = [A::zero(); K];
                 let mut result = NearestNeighbour {
                     distance: A::max_value(),
-                    item: T::zero(),
+                    item: T::default(),
                 };
 
                 if self.stems.is_empty() {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 //! Definitions and implementations for some traits that are common between the [`float`](crate::float), [`immutable`](crate::immutable) and [`fixed`](crate::fixed)  modules
 use az::Cast;
 use divrem::DivCeil;
-use num_traits::{One, PrimInt, Unsigned, Zero};
+use num_traits::{PrimInt, Unsigned, Zero};
 use std::fmt::Debug;
 
 /// Content trait.
@@ -11,22 +11,20 @@ use std::fmt::Debug;
 /// than 65535 points, you could use a `u16`. All these types implement `Content` with no
 /// extra changes. Start off with a `usize` as that's easiest
 /// since you won't need to cast to / from usize when using query results to index into
-/// a Vec, and try switching tqo a smaller type and benchmarking to see if you get better
-/// performance.
+/// a Vec, and try switching to a smaller type and benchmarking to see if you get better
+/// performance.  However, any type that satisfies these trait constraints may be used; in
+/// particular, we use T::default() to initialize the KdTree content.
 pub trait Content:
-    Zero + One + PartialEq + Default + Clone + Copy + Ord + Debug + std::ops::SubAssign + Sync + Send
+    PartialEq + Default + Clone + Copy + Ord + Debug + Sync + Send
 {
 }
 impl<
-        T: Zero
-            + One
-            + PartialEq
+        T: PartialEq
             + Default
             + Clone
             + Copy
             + Ord
             + Debug
-            + std::ops::SubAssign
             + Sync
             + Send,
     > Content for T

--- a/tests/string_data_test.rs
+++ b/tests/string_data_test.rs
@@ -1,0 +1,95 @@
+use kiddo::float::kdtree::KdTree;
+use kiddo::SquaredEuclidean;
+
+#[derive(Clone, Copy, Debug, PartialEq, Default, Eq, Ord, PartialOrd)]
+struct MyFixedString {
+    bytes: [u8; 32],
+}
+
+impl MyFixedString {
+    fn from_str(s: &str) -> Self {
+        let mut bytes = [0u8; 32];
+        let copy_length = s.as_bytes().len().min(32);
+        bytes[..copy_length].copy_from_slice(&s.as_bytes()[..copy_length]);
+        Self { bytes }
+    }
+    
+    fn as_str(&self) -> &str {
+        let len = self.bytes.iter().position(|&b| b == 0).unwrap_or(32);
+        std::str::from_utf8(&self.bytes[..len]).unwrap()
+    }
+}
+
+
+#[test]
+fn test_kdtree_with_numeric_id() {
+    // Create a new KdTree with 2D points (K=2) and u32 as the data type
+    let mut tree: KdTree<f64, u32, 2, 32, u32> = KdTree::new();
+    
+    // Add some points with associated numeric IDs
+    tree.add(&[0.0, 0.0], 1001);
+    tree.add(&[1.0, 1.0], 1002);
+    tree.add(&[2.0, 2.0], 1003);
+    tree.add(&[-1.0, -1.0], 1004);
+    
+    // Test nearest neighbor query
+    let query_point = [0.5, 0.25];
+    let nearest = tree.nearest_one::<SquaredEuclidean>(&query_point);
+    
+    // The closest point should be [0.0, 0.0] with ID 1001
+    assert_eq!(nearest.item, 1001);
+    //assert!((nearest.distance - 0.5).abs() < f64::EPSILON);
+    assert!((nearest.distance - (0.5f64*0.5+0.25*0.25).sqrt()) < f64::EPSILON);
+    
+    // Test k-nearest neighbors
+    let k_nearest = tree.nearest_n::<SquaredEuclidean>(&query_point, 2);
+    assert_eq!(k_nearest.len(), 2);
+    assert_eq!(k_nearest[0].item, 1001);
+    assert_eq!(k_nearest[1].item, 1002);
+    
+    // Test within radius
+    let radius = 2.0;
+    let within_results = tree.within::<SquaredEuclidean>(&query_point, radius);
+    assert_eq!(within_results.len(), 2); // Should find two points within radius
+    assert!(within_results.iter().any(|r| r.item == 1001));
+    assert!(within_results.iter().any(|r| r.item == 1002));
+}
+
+#[test]
+/// Test case with an esoteric T type
+fn test_kdtree_with_fixed_string() {
+    // Create a new KdTree with 2D points (K=2) and MyFixedString as the data type
+    let mut tree: KdTree<f64, MyFixedString, 2, 32, u32> = KdTree::new();
+    
+    // Add some points with associated MyFixedString data
+    tree.add(&[0.0, 0.0], MyFixedString::from_str("Origin"));
+    tree.add(&[1.0, 1.0], MyFixedString::from_str("Point A"));
+    tree.add(&[2.0, 2.0], MyFixedString::from_str("Point B"));
+    tree.add(&[-1.0, -1.0], MyFixedString::from_str("Point C"));
+    
+    // Test nearest neighbor query
+    let query_point = [0.5, 0.25];
+    let nearest = tree.nearest_one::<SquaredEuclidean>(&query_point);
+    
+    // The closest point should be [0.0, 0.0] with data "Origin"
+    assert_eq!(nearest.item.as_str(), "Origin");
+    assert!((nearest.distance - (0.5f64*0.5+0.25*0.25).sqrt()) < f64::EPSILON);
+    
+    let (nearest, nearest_point) = tree.nearest_one_point::<SquaredEuclidean>(&query_point);
+    
+    // The closest point should be [0.0, 0.0] with data "Origin"
+    assert_eq!(nearest.item.as_str(), "Origin");
+    assert_eq!(nearest_point, [0.0, 0.0]);
+    assert!((nearest.distance - (0.5f64*0.5+0.25*0.25).sqrt()) < f64::EPSILON);
+    
+    // Test k-nearest neighbors
+    let k_nearest = tree.nearest_n::<SquaredEuclidean>(&query_point, 2);
+    assert_eq!(k_nearest.len(), 2);
+    assert_eq!(k_nearest[0].item.as_str(), "Origin");
+    assert_eq!(k_nearest[1].item.as_str(), "Point A");
+    
+    // Test within radius
+    let radius = 2.0;
+    let within_results = tree.within::<SquaredEuclidean>(&query_point, radius);
+    assert_eq!(within_results.len(), 2); // Should find "Origin" and "Point A"
+}


### PR DESCRIPTION
This implementation attempts to resolve some long-standing requests, while minimizing internal code changes and reducing API changes affecting users as much as is practical.  Really, only the change of the KdTree.size from T to usize could require some minimal end-user code changes.  Since the trait constraints on T have been relaxed, that shouldn't affect users too  much (except to open up new opportunities for storing small but useful types directly in the KdTree).

o Relax the trait constraints on KdTree content type T and use T::default()
o Make KdTree.size a usize instead of a T, simplifying interface and semantics
o To allow use of the K-D Tree coordinates, provide nearest_one_point (in
  addition to nearest_one), which returns the NearestNeighbour and also the
  coordinate of the nearest K-D Tree point.

Fixes: #33 (didn't attempt T as () though)
Fixes: #93 (because, maybe now we can include small but useful types directly in the KdTree as type T?)


TODO: Move the tests/... to a more appropriate place

Comments?