### PR TITLE
Move `fixed` dependency behind a feature gate to reduce compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cmov = "0.3"
 divrem = "1"
 doc-comment = "0.3"
 elapsed = "0.1"
-fixed = { version = "1", features = ["num-traits"] }
+fixed = { version = "1", features = ["num-traits"], optional = true}
 init_with = "1"
 itertools = "0.14"
 log = "0.4"
@@ -119,15 +119,16 @@ optional = true
 
 [features]
 csv = ["dep:csv"]
-default = ["tracing"]
+default = ["tracing", "fixed"]
 modified_van_emde_boas = []
 f16 = ["dep:half"]
+fixed = ["dep:fixed"]
 global_allocate = []
 las = ["dep:las"]
 serde = ["dep:serde", "serde/derive", "dep:serde_derive", "dep:serde_with", "fixed/serde", "aligned-vec/serde"]
 simd = []
 rkyv = ["dep:rkyv"]
-test_utils = ["dep:rand", "dep:rand_chacha", "dep:rayon"]
+test_utils = ["dep:rand", "dep:rand_chacha", "dep:rayon", "dep:fixed"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ pub(crate) mod common;
 #[cfg(feature = "serde")]
 #[doc(hidden)]
 mod custom_serde;
+#[cfg(feature = "fixed")]
 pub mod fixed;
 pub mod float;
 pub mod immutable;


### PR DESCRIPTION
I use `kiddo` as a dependency in one of my projects. When building with `--timings`, I noticed that the `fixed` crate took up the a lot of the time. This is probably because `fixed` is a very heavy crate, so if we take it out, we get much better parallelism. If we gate the `fixed` dependency behind a feature, we cut the compilation time for `kiddo` roughly in half.

This holds for `cargo check`:
```txt
~/p/kiddo (master|✚2) [127]$ cargo -q clean && time cargo -q check --no-default-features
________________________________________________________
Executed in    3.68 secs    fish           external
   usr time   10.95 secs  540.00 micros   10.95 secs
   sys time    2.27 secs  248.00 micros    2.27 secs

~/p/kiddo (master|✚2) $ cargo -q clean && time cargo -q check --no-default-features --features fixed
________________________________________________________
Executed in    6.50 secs    fish           external
   usr time   17.13 secs  837.00 micros   17.13 secs
   sys time    2.92 secs   52.00 micros    2.92 secs
```

And it holds for release builds:
```txt
~/p/kiddo (master|✚2) $ cargo -q clean && time cargo -q build --release --no-default-features
________________________________________________________
Executed in    3.67 secs    fish           external
   usr time   12.77 secs  541.00 micros   12.77 secs
   sys time    2.27 secs  255.00 micros    2.27 secs

~/p/kiddo (master|✚2) $ cargo -q clean && time cargo -q build --release --no-default-features --features fixed
________________________________________________________
Executed in    7.99 secs    fish           external
   usr time   20.84 secs  301.00 micros   20.84 secs
   sys time    3.11 secs  142.00 micros    3.11 secs

```

The main issue is that this would be a breaking change for anyone who uses `no-default-features` in kiddo. There are ways of [preventing this in the future](https://slint.dev/blog/rust-adding-default-cargo-feature) using a mandatory compatibility feature, but we can't create that mandatory feature without a breaking change.

Thanks for maintaining this crate - it's really fast and a pleasure to use!