### PR TITLE
Feature/fixed as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ cmov = "0.3"
 divrem = "1"
 doc-comment = "0.3"
 elapsed = "0.1"
-fixed = { version = "1", features = ["num-traits"] }
 init_with = "1"
 itertools = "0.14"
 log = "0.4"
@@ -67,6 +66,10 @@ generator = "0.8.4"
 version = "1"
 optional = true
 
+[dependencies.fixed]
+version = "1"
+features = ["num-traits"]
+optional = true
 
 # half 2.5.0 switched from rkyv 0.7 to rkyv 0.8.
 [dependencies.half]
@@ -133,17 +136,18 @@ optional = true
 
 [features]
 csv = ["dep:csv"]
-default = ["tracing"]
+default = ["tracing", "fixed"]
 modified_van_emde_boas = []
 f16 = ["dep:half"]
 f16_rkyv_08 = ["dep:half_2_5", "rkyv_08"]
+fixed = ["dep:fixed"]
 global_allocate = []
 las = ["dep:las"]
 serde = ["dep:serde", "serde/derive", "dep:serde_derive", "dep:serde_with", "fixed/serde", "aligned-vec/serde"]
 simd = []
 rkyv = ["dep:rkyv"]
 rkyv_08 = ["dep:rkyv_08"]
-test_utils = ["dep:rand", "dep:rand_chacha", "dep:rayon"]
+test_utils = ["dep:rand", "dep:rand_chacha", "dep:rayon", "dep:fixed"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,22 +30,18 @@ az = "1"
 cmov = "0.3"
 divrem = "1"
 doc-comment = "0.3"
-elapsed = "0.1"
-init_with = "1"
-itertools = "0.14"
-log = "0.4"
 num-traits = "0.2"
 ordered-float = "5"
 sorted-vec = "0.8"
-ubyte = "0.10"
 
 [dev-dependencies]
 bincode = "1.3"
 codspeed-criterion-compat = "2"
 criterion = "0.5"
+elapsed = "0.1"
 flate2 = { version = "1", features = ["zlib-ng-compat"], default-features = false }
+itertools = "0.14"
 las = { version = "0.9", features = ["laz-parallel"] }
-log = "0.4"
 memmap = "0.7"
 proc-macro2 = { version = "1", features=["default", "proc-macro"] }
 radians = "0.3"
@@ -55,6 +51,7 @@ rayon = "1"
 rstest = "0.25"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
+ubyte = "0.10"
 # required to be able to run tests without specifying --features=test_utils
 # see https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 kiddo = { path = ".", features = ["test_utils"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub(crate) mod common;
 #[cfg(feature = "serde")]
 #[doc(hidden)]
 mod custom_serde;
+#[cfg(feature = "fixed")]
 pub mod fixed;
 pub mod float;
 pub mod immutable;


### PR DESCRIPTION
Rebase of @claytonwramsey's PR, https://github.com/sdd/kiddo/pull/218, on top of latest master.

Additionally, cleaned up some unused deps and moved `itertools` (as per https://github.com/sdd/kiddo/pull/218#issuecomment-2956835612) as well as `elapsed` and `ubyte` to dev-dependencies.