### PR TITLE
Update `within_unsorted_iter` to relax lifetime requirements of the query parameter

### DIFF
--- a/src/common/generate_within_unsorted_iter.rs
+++ b/src/common/generate_within_unsorted_iter.rs
@@ -45,6 +45,7 @@ macro_rules! generate_within_unsorted_iter {
                 D: DistanceMetric<A, K>,
             {
                 let mut off = [A::zero(); K];
+                let root_index: IDX = *transform(&self.root_index);
 
                 let gen = Gn::new_scoped(move |gen_scope| {
                     let query_ref = &query;
@@ -52,7 +53,7 @@ macro_rules! generate_within_unsorted_iter {
                         self.within_unsorted_iter_recurse::<D>(
                             query_ref,
                             dist,
-                            self.root_index,
+                            root_index,
                             0,
                             gen_scope,
                             &mut off,

--- a/src/common/generate_within_unsorted_iter.rs
+++ b/src/common/generate_within_unsorted_iter.rs
@@ -7,7 +7,7 @@ macro_rules! generate_within_unsorted_iter {
             #[inline]
             pub fn within_unsorted_iter<D>(
                 &'a self,
-                query: &'a [A; K],
+                query: &'query [A; K],
                 dist: A,
             ) -> WithinUnsortedIter<'a, A, T>
             where
@@ -16,37 +16,7 @@ macro_rules! generate_within_unsorted_iter {
                 let mut off = [A::zero(); K];
                 let root_index: IDX = *transform(&self.root_index);
 
-                let gen = Gn::new_scoped(move |gen_scope| {
-                    unsafe {
-                        self.within_unsorted_iter_recurse::<D>(
-                            query,
-                            dist,
-                            root_index,
-                            0,
-                            gen_scope,
-                            &mut off,
-                            A::zero(),
-                        );
-                    }
-
-                    done!();
-                });
-
-                WithinUnsortedIter::new(gen)
-            }
-
-            #[inline]
-            pub fn within_unsorted_iter_owned<D>(
-                &'a self,
-                query: [A; K],
-                dist: A,
-            ) -> WithinUnsortedIterOwned<'a, A, T>
-            where
-                D: DistanceMetric<A, K>,
-            {
-                let mut off = [A::zero(); K];
-                let root_index: IDX = *transform(&self.root_index);
-
+                let query = query.clone();
                 let gen = Gn::new_scoped(move |gen_scope| {
                     let query_ref = &query;
                     unsafe {
@@ -64,7 +34,7 @@ macro_rules! generate_within_unsorted_iter {
                     done!();
                 });
 
-                WithinUnsortedIterOwned::new(gen)
+                WithinUnsortedIter::new(gen)
             }
 
             #[allow(clippy::too_many_arguments)]

--- a/src/common/generate_within_unsorted_iter.rs
+++ b/src/common/generate_within_unsorted_iter.rs
@@ -35,6 +35,37 @@ macro_rules! generate_within_unsorted_iter {
                 WithinUnsortedIter::new(gen)
             }
 
+            #[inline]
+            pub fn within_unsorted_iter_owned<D>(
+                &'a self,
+                query: [A; K],
+                dist: A,
+            ) -> WithinUnsortedIterOwned<'a, A, T>
+            where
+                D: DistanceMetric<A, K>,
+            {
+                let mut off = [A::zero(); K];
+
+                let gen = Gn::new_scoped(move |gen_scope| {
+                    let query_ref = &query;
+                    unsafe {
+                        self.within_unsorted_iter_recurse::<D>(
+                            query_ref,
+                            dist,
+                            self.root_index,
+                            0,
+                            gen_scope,
+                            &mut off,
+                            A::zero(),
+                        );
+                    }
+
+                    done!();
+                });
+
+                WithinUnsortedIterOwned::new(gen)
+            }
+
             #[allow(clippy::too_many_arguments)]
             unsafe fn within_unsorted_iter_recurse<'scope, D>(
                 &'a self,

--- a/src/fixed/query/within_unsorted_iter.rs
+++ b/src/fixed/query/within_unsorted_iter.rs
@@ -7,12 +7,19 @@ use crate::nearest_neighbour::NearestNeighbour;
 use crate::rkyv_utils::transform;
 use crate::traits::DistanceMetric;
 use crate::traits::{is_stem_index, Content, Index};
-use crate::within_unsorted_iter::{WithinUnsortedIter, WithinUnsortedIterOwned};
+use crate::within_unsorted_iter::WithinUnsortedIter;
 
 use crate::generate_within_unsorted_iter;
 
-impl<'a, A: Axis, T: Content, const K: usize, const B: usize, IDX: Index<T = IDX> + Send>
-    KdTree<A, T, K, B, IDX>
+impl<
+        'a,
+        'query,
+        A: Axis,
+        T: Content,
+        const K: usize,
+        const B: usize,
+        IDX: Index<T = IDX> + Send,
+    > KdTree<A, T, K, B, IDX>
 where
     usize: Cast<IDX>,
 {

--- a/src/fixed/query/within_unsorted_iter.rs
+++ b/src/fixed/query/within_unsorted_iter.rs
@@ -7,7 +7,7 @@ use crate::nearest_neighbour::NearestNeighbour;
 use crate::rkyv_utils::transform;
 use crate::traits::DistanceMetric;
 use crate::traits::{is_stem_index, Content, Index};
-use crate::within_unsorted_iter::WithinUnsortedIter;
+use crate::within_unsorted_iter::{WithinUnsortedIter, WithinUnsortedIterOwned};
 
 use crate::generate_within_unsorted_iter;
 

--- a/src/float/query/within_unsorted_iter.rs
+++ b/src/float/query/within_unsorted_iter.rs
@@ -7,7 +7,7 @@ use crate::nearest_neighbour::NearestNeighbour;
 use crate::rkyv_utils::transform;
 use crate::traits::DistanceMetric;
 use crate::traits::{is_stem_index, Content, Index};
-use crate::within_unsorted_iter::WithinUnsortedIter;
+use crate::within_unsorted_iter::{WithinUnsortedIter, WithinUnsortedIterOwned};
 
 use crate::generate_within_unsorted_iter;
 

--- a/src/within_unsorted_iter.rs
+++ b/src/within_unsorted_iter.rs
@@ -18,3 +18,19 @@ impl<A, T> Iterator for WithinUnsortedIter<'_, A, T> {
         self.0.next()
     }
 }
+
+pub struct WithinUnsortedIterOwned<'a, A, T>(Generator<'a, (), NearestNeighbour<A, T>>);
+
+impl<'a, A, T> WithinUnsortedIterOwned<'a, A, T> {
+    pub(crate) fn new(gen: Generator<'a, (), NearestNeighbour<A, T>>) -> Self {
+        WithinUnsortedIterOwned(gen)
+    }
+}
+
+impl<A, T> Iterator for WithinUnsortedIterOwned<'_, A, T> {
+    type Item = NearestNeighbour<A, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}

--- a/src/within_unsorted_iter.rs
+++ b/src/within_unsorted_iter.rs
@@ -18,19 +18,3 @@ impl<A, T> Iterator for WithinUnsortedIter<'_, A, T> {
         self.0.next()
     }
 }
-
-pub struct WithinUnsortedIterOwned<'a, A, T>(Generator<'a, (), NearestNeighbour<A, T>>);
-
-impl<'a, A, T> WithinUnsortedIterOwned<'a, A, T> {
-    pub(crate) fn new(gen: Generator<'a, (), NearestNeighbour<A, T>>) -> Self {
-        WithinUnsortedIterOwned(gen)
-    }
-}
-
-impl<A, T> Iterator for WithinUnsortedIterOwned<'_, A, T> {
-    type Item = NearestNeighbour<A, T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}


### PR DESCRIPTION
`within_unsorted_iter` is modified to decouple the lifetime of the iterator from that of the query by performing a generally very cheap copy just once at the start of the query.

Since we're targetting low-dimensionality use cases with 2-4 dimensions being the primary target use case, the clone here will range from 4 bytes for a 2D `f16` to 32 bytes for a 4D `f64` tree, vs a likely 8-byte copy for a pointer. The clone could even end up optimised away into CPU registers, but even in the case of a 32 byte copy we're talking just a few nanoseconds  per query.