### PR TITLE
Fix distance.rs doc for Manhatten distance

### DIFF
--- a/src/fixed/distance.rs
+++ b/src/fixed/distance.rs
@@ -8,10 +8,9 @@
 use crate::fixed::kdtree::Axis;
 use crate::traits::DistanceMetric;
 
-/// Returns the squared euclidean distance between two points. When you only
-/// need to compare distances, rather than having the exact distance between
-/// the points, this metric is beneficial because it avoids the expensive square
-/// root computation.
+/// Returns the Manhattan / "taxi cab" distance between two points.
+///
+/// Faster than squared Euclidean, and just as effective if not more so in higher-dimensional spaces
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The description in the docs had an oversight and used the same desc as squaredEuclidean distance